### PR TITLE
(DOCSP-43336) Adds stub pages and toctree for Atlas Archi Center

### DIFF
--- a/source/auditing-logging.txt
+++ b/source/auditing-logging.txt
@@ -1,0 +1,53 @@
+.. _arch-center-auditing-logging:
+
+====================
+Auditing and Logging 
+====================
+
+.. default-domain:: mongodb
+
+.. contents:: On this page
+   :local:
+   :backlinks: none
+   :depth: 1
+   :class: onecol
+
+Intro statement
+
+{+service+} Features and Best Practices for Auditing and Logging
+----------------------------------------------------------------
+
+Content here
+
+Examples
+--------
+
+The following examples <perform this action> using |service| tools for automation (link).
+
+.. tabs::
+
+   .. tab:: API
+      :tabid: api
+
+      Content here
+
+   .. tab:: CLI
+      :tabid: cli
+
+      Content here
+
+   .. tab:: Terraform
+      :tabid: Terraform
+
+      Content here
+
+   .. tab:: CDK
+      :tabid: CDK
+
+      Content here
+
+   .. tab:: AKO
+      :tabid: ako
+
+      Content here
+

--- a/source/auth.txt
+++ b/source/auth.txt
@@ -1,0 +1,53 @@
+.. _arch-center-auth:
+
+================================
+Authorization and Authentication
+================================
+
+.. default-domain:: mongodb
+
+.. contents:: On this page
+   :local:
+   :backlinks: none
+   :depth: 1
+   :class: onecol
+
+Intro statement
+
+{+service+} Features and Best Practices for Authorization and Authentication
+---------------------------------------------------------------------------------------
+
+Content here
+
+Examples
+--------
+
+The following examples <perform this action> using |service| tools for automation (link).
+
+.. tabs::
+
+   .. tab:: API
+      :tabid: api
+
+      Content here
+
+   .. tab:: CLI
+      :tabid: cli
+
+      Content here
+
+   .. tab:: Terraform
+      :tabid: Terraform
+
+      Content here
+
+   .. tab:: CDK
+      :tabid: CDK
+
+      Content here
+
+   .. tab:: AKO
+      :tabid: ako
+
+      Content here
+

--- a/source/automation.txt
+++ b/source/automation.txt
@@ -1,0 +1,53 @@
+.. _arch-center-automation:
+
+==========
+Automation
+==========
+
+.. default-domain:: mongodb
+
+.. contents:: On this page
+   :local:
+   :backlinks: none
+   :depth: 1
+   :class: onecol
+
+Intro statement
+
+{+service+} Features and Best Practices for Automation
+------------------------------------------------------
+
+Content here
+
+Examples
+--------
+
+The following examples <perform this action> using |service| tools for automation (link).
+
+.. tabs::
+
+   .. tab:: API
+      :tabid: api
+
+      Content here
+
+   .. tab:: CLI
+      :tabid: cli
+
+      Content here
+
+   .. tab:: Terraform
+      :tabid: Terraform
+
+      Content here
+
+   .. tab:: CDK
+      :tabid: CDK
+
+      Content here
+
+   .. tab:: AKO
+      :tabid: ako
+
+      Content here
+

--- a/source/backup-transfer-query-config.txt
+++ b/source/backup-transfer-query-config.txt
@@ -1,0 +1,53 @@
+.. _arch-center-backup-transfer-query:
+
+=========================================
+Backup, Transfer, and Query Configuration
+=========================================
+
+.. default-domain:: mongodb
+
+.. contents:: On this page
+   :local:
+   :backlinks: none
+   :depth: 1
+   :class: onecol
+
+Intro statement
+
+{+service+} Features and Best Practices for Backup, Transfer, and Query Configuration
+------------------------------------------------------------------------------------
+
+Content here
+
+Examples
+--------
+
+The following examples <perform this action> using |service| tools for automation (link).
+
+.. tabs::
+
+   .. tab:: API
+      :tabid: api
+
+      Content here
+
+   .. tab:: CLI
+      :tabid: cli
+
+      Content here
+
+   .. tab:: Terraform
+      :tabid: Terraform
+
+      Content here
+
+   .. tab:: CDK
+      :tabid: CDK
+
+      Content here
+
+   .. tab:: AKO
+      :tabid: ako
+
+      Content here
+

--- a/source/backups.txt
+++ b/source/backups.txt
@@ -1,0 +1,53 @@
+.. _arch-center-backups:
+
+=======
+Backups
+=======
+
+.. default-domain:: mongodb
+
+.. contents:: On this page
+   :local:
+   :backlinks: none
+   :depth: 1
+   :class: onecol
+
+Intro statement
+
+{+service+} Features and Best Practices for Backups
+---------------------------------------------------
+
+Content here
+
+Examples
+--------
+
+The following examples <perform this action> using |service| tools for automation (link).
+
+.. tabs::
+
+   .. tab:: API
+      :tabid: api
+
+      Content here
+
+   .. tab:: CLI
+      :tabid: cli
+
+      Content here
+
+   .. tab:: Terraform
+      :tabid: Terraform
+
+      Content here
+
+   .. tab:: CDK
+      :tabid: CDK
+
+      Content here
+
+   .. tab:: AKO
+      :tabid: ako
+
+      Content here
+

--- a/source/billing-data.txt
+++ b/source/billing-data.txt
@@ -1,0 +1,53 @@
+.. _arch-center-billing-data:
+
+============
+Billing Data 
+============
+
+.. default-domain:: mongodb
+
+.. contents:: On this page
+   :local:
+   :backlinks: none
+   :depth: 1
+   :class: onecol
+
+Intro statement
+
+{+service+} Features and Best Practices for Billing Data
+--------------------------------------------------------
+
+Content here
+
+Examples
+--------
+
+The following examples <perform this action> using |service| tools for automation (link).
+
+.. tabs::
+
+   .. tab:: API
+      :tabid: api
+
+      Content here
+
+   .. tab:: CLI
+      :tabid: cli
+
+      Content here
+
+   .. tab:: Terraform
+      :tabid: Terraform
+
+      Content here
+
+   .. tab:: CDK
+      :tabid: CDK
+
+      Content here
+
+   .. tab:: AKO
+      :tabid: ako
+
+      Content here
+

--- a/source/cluster-config.txt
+++ b/source/cluster-config.txt
@@ -1,0 +1,53 @@
+.. _arch-center-cluster-config:
+
+=====================
+Cluster Configuration 
+=====================
+
+.. default-domain:: mongodb
+
+.. contents:: On this page
+   :local:
+   :backlinks: none
+   :depth: 1
+   :class: onecol
+
+Intro statement
+
+{+service+} Features and Best Practices for Cluster Configuration
+-----------------------------------------------------------------
+
+Content here
+
+Examples
+--------
+
+The following examples <perform this action> using |service| tools for automation (link).
+
+.. tabs::
+
+   .. tab:: API
+      :tabid: api
+
+      Content here
+
+   .. tab:: CLI
+      :tabid: cli
+
+      Content here
+
+   .. tab:: Terraform
+      :tabid: Terraform
+
+      Content here
+
+   .. tab:: CDK
+      :tabid: CDK
+
+      Content here
+
+   .. tab:: AKO
+      :tabid: ako
+
+      Content here
+

--- a/source/compliance.txt
+++ b/source/compliance.txt
@@ -1,0 +1,53 @@
+.. _arch-center-compliance:
+
+==========
+Compliance
+==========
+
+.. default-domain:: mongodb
+
+.. contents:: On this page
+   :local:
+   :backlinks: none
+   :depth: 1
+   :class: onecol
+
+Intro statement
+
+{+service+} Features and Best Practices for Compliance
+------------------------------------------------------
+
+Content here
+
+Examples
+--------
+
+The following examples <perform this action> using |service| tools for automation (link).
+
+.. tabs::
+
+   .. tab:: API
+      :tabid: api
+
+      Content here
+
+   .. tab:: CLI
+      :tabid: cli
+
+      Content here
+
+   .. tab:: Terraform
+      :tabid: Terraform
+
+      Content here
+
+   .. tab:: CDK
+      :tabid: CDK
+
+      Content here
+
+   .. tab:: AKO
+      :tabid: ako
+
+      Content here
+

--- a/source/cost-optimization.txt
+++ b/source/cost-optimization.txt
@@ -1,0 +1,22 @@
+=================
+Cost Optimization
+=================
+
+.. default-domain:: mongodb
+
+Use the following resources to learn about cost optimization in
+{+service+}:
+
+- :ref:`Cluster Configuration <arch-center-cluster-config>`
+- :ref:`Backup, Transfer, and Query Configuration <arch-center-backup-transfer-query>`
+- :ref:`Data Storage <arch-center-data-storage>`
+- :ref:`Billing Data <arch-center-billing-data>`
+
+
+.. toctree::
+   :titlesonly:
+
+   Cluster Configuration </cluster-config>
+   Backups, Transfers, and Queries </backup-transfer-query-config>
+   Data Storage </data-storage>
+   Billing Data </billing-data>

--- a/source/data-encryption.txt
+++ b/source/data-encryption.txt
@@ -1,0 +1,53 @@
+.. _arch-center-data-encryption:
+
+===============
+Data Encryption 
+===============
+
+.. default-domain:: mongodb
+
+.. contents:: On this page
+   :local:
+   :backlinks: none
+   :depth: 1
+   :class: onecol
+
+Intro statement
+
+{+service+} Features and Best Practices for Data Encryption
+-----------------------------------------------------------
+
+Content here
+
+Examples
+--------
+
+The following examples <perform this action> using |service| tools for automation (link).
+
+.. tabs::
+
+   .. tab:: API
+      :tabid: api
+
+      Content here
+
+   .. tab:: CLI
+      :tabid: cli
+
+      Content here
+
+   .. tab:: Terraform
+      :tabid: Terraform
+
+      Content here
+
+   .. tab:: CDK
+      :tabid: CDK
+
+      Content here
+
+   .. tab:: AKO
+      :tabid: ako
+
+      Content here
+

--- a/source/data-storage.txt
+++ b/source/data-storage.txt
@@ -1,0 +1,53 @@
+.. _arch-center-data-storage:
+
+============
+Data Storage
+============
+
+.. default-domain:: mongodb
+
+.. contents:: On this page
+   :local:
+   :backlinks: none
+   :depth: 1
+   :class: onecol
+
+Intro statement
+
+{+service+} Features and Best Practices for Data Storage
+--------------------------------------------------------
+
+Content here
+
+Examples
+--------
+
+The following examples <perform this action> using |service| tools for automation (link).
+
+.. tabs::
+
+   .. tab:: API
+      :tabid: api
+
+      Content here
+
+   .. tab:: CLI
+      :tabid: cli
+
+      Content here
+
+   .. tab:: Terraform
+      :tabid: Terraform
+
+      Content here
+
+   .. tab:: CDK
+      :tabid: CDK
+
+      Content here
+
+   .. tab:: AKO
+      :tabid: ako
+
+      Content here
+

--- a/source/getting-started.txt
+++ b/source/getting-started.txt
@@ -1,0 +1,17 @@
+=========================================================
+Getting Started with the {+atlas-arch-center+}
+=========================================================
+
+.. default-domain:: mongodb
+
+Use the following resources to get started with the 
+{+atlas-arch-center+}:
+
+- :ref:`Landing Zone Design <arch-center-landing-zone>`
+- :ref:`Migration <arch-center-migration>`
+
+.. toctree::
+   :titlesonly:
+
+   Landing Zone Design </landing-zone>
+   Migration </migration>

--- a/source/hierarchy.txt
+++ b/source/hierarchy.txt
@@ -1,0 +1,53 @@
+.. _arch-center-hierarchy:
+
+===============================================
+Organization, Project, and Deployment Hierarchy 
+===============================================
+
+.. default-domain:: mongodb
+
+.. contents:: On this page
+   :local:
+   :backlinks: none
+   :depth: 1
+   :class: onecol
+
+Intro statement
+
+{+service+} Features and Best Practices for Hierarchy
+-----------------------------------------------------
+
+Content here
+
+Examples
+--------
+
+The following examples <perform this action> using |service| tools for automation (link).
+
+.. tabs::
+
+   .. tab:: API
+      :tabid: api
+
+      Content here
+
+   .. tab:: CLI
+      :tabid: cli
+
+      Content here
+
+   .. tab:: Terraform
+      :tabid: Terraform
+
+      Content here
+
+   .. tab:: CDK
+      :tabid: CDK
+
+      Content here
+
+   .. tab:: AKO
+      :tabid: ako
+
+      Content here
+

--- a/source/high-availability.txt
+++ b/source/high-availability.txt
@@ -1,0 +1,53 @@
+.. _arch-center-high-availability:
+
+=================
+High Availability
+=================
+
+.. default-domain:: mongodb
+
+.. contents:: On this page
+   :local:
+   :backlinks: none
+   :depth: 1
+   :class: onecol
+
+Intro statement
+
+{+service+} Features and Best Practices for High Availability
+-------------------------------------------------------------
+
+Content here
+
+Examples
+--------
+
+The following examples <perform this action> using |service| tools for automation (link).
+
+.. tabs::
+
+   .. tab:: API
+      :tabid: api
+
+      Content here
+
+   .. tab:: CLI
+      :tabid: cli
+
+      Content here
+
+   .. tab:: Terraform
+      :tabid: Terraform
+
+      Content here
+
+   .. tab:: CDK
+      :tabid: CDK
+
+      Content here
+
+   .. tab:: AKO
+      :tabid: ako
+
+      Content here
+

--- a/source/index.txt
+++ b/source/index.txt
@@ -6,3 +6,12 @@
 
 Landing page content
 
+.. toctree::
+   :titlesonly:
+
+   Getting Started </getting-started>
+   Operational Efficiency </operational-efficiency>
+   Security </security>
+   Reliability </reliability>
+   Performance </performance>
+   Cost Optimization </cost-optimization>

--- a/source/landing-zone.txt
+++ b/source/landing-zone.txt
@@ -1,0 +1,17 @@
+.. _arch-center-landing-zone:
+
+===================
+Landing Zone Design
+===================
+
+.. default-domain:: mongodb
+
+.. contents:: On this page
+   :local:
+   :backlinks: none
+   :depth: 1
+   :class: onecol
+
+Intro statement
+
+Content here

--- a/source/migration.txt
+++ b/source/migration.txt
@@ -1,0 +1,17 @@
+.. _arch-center-migration:
+
+=========
+Migration
+=========
+
+.. default-domain:: mongodb
+
+.. contents:: On this page
+   :local:
+   :backlinks: none
+   :depth: 1
+   :class: onecol
+
+Intro statement
+
+Content here

--- a/source/monitoring-alerts.txt
+++ b/source/monitoring-alerts.txt
@@ -1,0 +1,53 @@
+.. _arch-center-monitoring-alerts:
+
+=====================
+Monitoring and Alerts
+=====================
+
+.. default-domain:: mongodb
+
+.. contents:: On this page
+   :local:
+   :backlinks: none
+   :depth: 1
+   :class: onecol
+
+Intro statement
+
+{+service+} Features and Best Practices for Monitoring and Alerts
+-----------------------------------------------------------------
+
+Content here
+
+Examples
+--------
+
+The following examples <perform this action> using |service| tools for automation (link).
+
+.. tabs::
+
+   .. tab:: API
+      :tabid: api
+
+      Content here
+
+   .. tab:: CLI
+      :tabid: cli
+
+      Content here
+
+   .. tab:: Terraform
+      :tabid: Terraform
+
+      Content here
+
+   .. tab:: CDK
+      :tabid: CDK
+
+      Content here
+
+   .. tab:: AKO
+      :tabid: ako
+
+      Content here
+

--- a/source/multi-cloud-multi-region.txt
+++ b/source/multi-cloud-multi-region.txt
@@ -1,0 +1,53 @@
+.. _arch-center-multi-cloud-region:
+
+========================================
+Multi-Cloud and Multi-Region Deployments
+========================================
+
+.. default-domain:: mongodb
+
+.. contents:: On this page
+   :local:
+   :backlinks: none
+   :depth: 1
+   :class: onecol
+
+Intro statement
+
+{+service+} Features and Best Practices for Multi-Cloud and Multi-Region Deployments
+-----------------------------------------------------------------------------------------
+
+Content here
+
+Examples
+--------
+
+The following examples <perform this action> using |service| tools for automation (link).
+
+.. tabs::
+
+   .. tab:: API
+      :tabid: api
+
+      Content here
+
+   .. tab:: CLI
+      :tabid: cli
+
+      Content here
+
+   .. tab:: Terraform
+      :tabid: Terraform
+
+      Content here
+
+   .. tab:: CDK
+      :tabid: CDK
+
+      Content here
+
+   .. tab:: AKO
+      :tabid: ako
+
+      Content here
+

--- a/source/network-security.txt
+++ b/source/network-security.txt
@@ -1,0 +1,53 @@
+.. _arch-center-network-security:
+
+================
+Network Security 
+================
+
+.. default-domain:: mongodb
+
+.. contents:: On this page
+   :local:
+   :backlinks: none
+   :depth: 1
+   :class: onecol
+
+Intro statement
+
+{+service+} Features and Best Practices for Network Security
+------------------------------------------------------------
+
+Content here
+
+Examples
+--------
+
+The following examples <perform this action> using |service| tools for automation (link).
+
+.. tabs::
+
+   .. tab:: API
+      :tabid: api
+
+      Content here
+
+   .. tab:: CLI
+      :tabid: cli
+
+      Content here
+
+   .. tab:: Terraform
+      :tabid: Terraform
+
+      Content here
+
+   .. tab:: CDK
+      :tabid: CDK
+
+      Content here
+
+   .. tab:: AKO
+      :tabid: ako
+
+      Content here
+

--- a/source/operational-efficiency.txt
+++ b/source/operational-efficiency.txt
@@ -1,0 +1,17 @@
+======================
+Operational Efficiency
+======================
+
+.. default-domain:: mongodb
+
+Use the following resources to learn about operational efficiency
+in {+service+}:
+
+- :ref:`Automation <arch-center-automation>`
+- :ref:`Monitoring and Alerts <arch-center-monitoring-alerts>`
+
+.. toctree::
+   :titlesonly:
+
+   Automation </automation>
+   Monitoring and Alerts </monitoring-alerts>

--- a/source/performance.txt
+++ b/source/performance.txt
@@ -1,0 +1,16 @@
+===========
+Performance
+===========
+
+.. default-domain:: mongodb
+
+Use the following resources to learn about performance in {+service+}:
+
+- :ref:`Scalability <arch-center-scalability>`
+- :ref:`Multi-Cloud and Multi-Region Deployments <arch-center-multi-cloud-region>`
+
+.. toctree::
+   :titlesonly:
+
+   Scalability </scalability>
+   Multi-Cloud and Multi-Region </multi-cloud-multi-region>

--- a/source/reliability.txt
+++ b/source/reliability.txt
@@ -1,0 +1,18 @@
+===========
+Reliability
+===========
+
+.. default-domain:: mongodb
+
+Use the following resources to learn about reliability in {+service+}:
+
+- :ref:`High Availability <arch-center-high-availability>`
+- :ref:`Application and Database Resiliency <arch-center-resiliency>`
+- :ref:`Backups <arch-center-backups>`
+
+.. toctree::
+   :titlesonly:
+
+   High Availability </high-availability>
+   Resiliency </resiliency>
+   Backups </backups>

--- a/source/resiliency.txt
+++ b/source/resiliency.txt
@@ -1,0 +1,53 @@
+.. _arch-center-resiliency:
+
+===================================
+Application and Database Resiliency
+===================================
+
+.. default-domain:: mongodb
+
+.. contents:: On this page
+   :local:
+   :backlinks: none
+   :depth: 1
+   :class: onecol
+
+Intro statement
+
+{+service+} Features and Best Practices for Resiliency
+------------------------------------------------------
+
+Content here
+
+Examples
+--------
+
+The following examples <perform this action> using |service| tools for automation (link).
+
+.. tabs::
+
+   .. tab:: API
+      :tabid: api
+
+      Content here
+
+   .. tab:: CLI
+      :tabid: cli
+
+      Content here
+
+   .. tab:: Terraform
+      :tabid: Terraform
+
+      Content here
+
+   .. tab:: CDK
+      :tabid: CDK
+
+      Content here
+
+   .. tab:: AKO
+      :tabid: ako
+
+      Content here
+

--- a/source/scalability.txt
+++ b/source/scalability.txt
@@ -1,0 +1,53 @@
+.. _arch-center-scalability:
+
+===========
+Scalability
+===========
+
+.. default-domain:: mongodb
+
+.. contents:: On this page
+   :local:
+   :backlinks: none
+   :depth: 1
+   :class: onecol
+
+Intro statement
+
+{+service+} Features and Best Practices for Scalability
+-------------------------------------------------------
+
+Content here
+
+Examples
+--------
+
+The following examples <perform this action> using |service| tools for automation (link).
+
+.. tabs::
+
+   .. tab:: API
+      :tabid: api
+
+      Content here
+
+   .. tab:: CLI
+      :tabid: cli
+
+      Content here
+
+   .. tab:: Terraform
+      :tabid: Terraform
+
+      Content here
+
+   .. tab:: CDK
+      :tabid: CDK
+
+      Content here
+
+   .. tab:: AKO
+      :tabid: ako
+
+      Content here
+

--- a/source/security.txt
+++ b/source/security.txt
@@ -1,0 +1,27 @@
+========
+Security
+========
+
+.. default-domain:: mongodb
+
+Use the following resources to learn about security in {+service+}:
+
+- :ref:`Organization, Project, and Deployment Hierarchy
+  <arch-center-hierarchy>`
+- :ref:`Network Security <arch-center-network-security>`
+- :ref:`Authorization and Authentication <arch-center-auth>`
+- :ref:`Data Encryption <arch-center-data-encryption>`
+- :ref:`Compliance <arch-center-compliance>`
+- :ref:`Auditing and Logging <arch-center-auditing-logging>`
+
+.. toctree::
+   :titlesonly:
+
+   Orgs, Projects, and Deployments </hierarchy>
+   Network Security </network-security>
+   Authorization and Authentication </auth>
+   Data Encryption </data-encryption>
+   Compliance </compliance>
+   Auditing and Logging </auditing-logging>
+
+


### PR DESCRIPTION
[DOCSP](https://jira.mongodb.org/browse/DOCSP-43336)
[Staging](https://deploy-preview-2--docs-atlas-architecture.netlify.app/)

Adds the TOC as approved in the project plan. See the IA for the approved page structure: https://docs.google.com/spreadsheets/d/1drrLAqtGPnLpjJjB8sbknwL87LMrVsMLgSYo3r-8AfQ/edit?gid=1312724988#gid=1312724988