### PR TITLE
(DOCSP-43341) Adds shared CLI code examples for hierarchy

### DIFF
--- a/snooty.toml
+++ b/snooty.toml
@@ -16,7 +16,9 @@ intersphinx = [ "https://www.mongodb.com/docs/master/objects.inv",
                 "https://www.mongodb.com/docs/php-library/current/objects.inv",
                 "https://www.mongodb.com/docs/drivers/rust/current/objects.inv",
                 "https://www.mongodb.com/docs/languages/scala/scala-driver/current/objects.inv",
-                "https://www.mongodb.com/docs/ruby-driver/current/objects.inv"
+                "https://www.mongodb.com/docs/ruby-driver/current/objects.inv",
+                "https://www.mongodb.com/docs/atlas/cli/current/objects.inv",
+                "https://www.mongodb.com/docs/atlas/objects.inv"
               ]
 
 # toc_landing_pages = ["/paths/to/pages/that/have/nested/content"]

--- a/source/auditing-logging.txt
+++ b/source/auditing-logging.txt
@@ -25,9 +25,17 @@ Examples
 The following examples <perform this action> using |service|
 :ref:`tools for automation <arch-center-automation>`.
 
-These examples also apply other recommended configurations, including:
+.. tabs::
 
-.. include:: /includes/shared-settings-clusters.rst
+   .. tab:: Dev and Test Environments
+      :tabid: devtest
+
+      .. include:: /includes/shared-settings-clusters-devtest.rst
+
+   .. tab:: Staging and Prod Environments
+      :tabid: stagingprod
+
+      .. include:: /includes/shared-settings-clusters-stagingprod.rst
 
 .. tabs::
 
@@ -46,8 +54,8 @@ These examples also apply other recommended configurations, including:
 
       Content here
 
-   .. tab:: CDK
-      :tabid: CDK
+   .. tab:: CloudFormation
+      :tabid: CloudFormation
 
       Content here
 

--- a/source/auth.txt
+++ b/source/auth.txt
@@ -27,7 +27,17 @@ The following examples <perform this action> using |service|
 
 These examples also apply other recommended configurations, including:
 
-.. include:: /includes/shared-settings-clusters.rst
+.. tabs::
+
+   .. tab:: Dev and Test Environments
+      :tabid: devtest
+
+      .. include:: /includes/shared-settings-clusters-devtest.rst
+
+   .. tab:: Staging and Prod Environments
+      :tabid: stagingprod
+
+      .. include:: /includes/shared-settings-clusters-stagingprod.rst
 
 .. tabs::
 
@@ -46,8 +56,8 @@ These examples also apply other recommended configurations, including:
 
       Content here
 
-   .. tab:: CDK
-      :tabid: CDK
+   .. tab:: CloudFormation
+      :tabid: CloudFormation
 
       Content here
 

--- a/source/automation.txt
+++ b/source/automation.txt
@@ -27,7 +27,17 @@ The following examples <perform this action> using |service|
 
 These examples also apply other recommended configurations, including:
 
-.. include:: /includes/shared-settings-clusters.rst
+.. tabs::
+
+   .. tab:: Dev and Test Environments
+      :tabid: devtest
+
+      .. include:: /includes/shared-settings-clusters-devtest.rst
+
+   .. tab:: Staging and Prod Environments
+      :tabid: stagingprod
+
+      .. include:: /includes/shared-settings-clusters-stagingprod.rst
 
 .. tabs::
 
@@ -46,8 +56,8 @@ These examples also apply other recommended configurations, including:
 
       Content here
 
-   .. tab:: CDK
-      :tabid: CDK
+   .. tab:: CloudFormation
+      :tabid: CloudFormation
 
       Content here
 

--- a/source/backup-transfer-query-config.txt
+++ b/source/backup-transfer-query-config.txt
@@ -27,7 +27,17 @@ The following examples <perform this action> using |service|
 
 These examples also apply other recommended configurations, including:
 
-.. include:: /includes/shared-settings-clusters.rst
+.. tabs::
+
+   .. tab:: Dev and Test Environments
+      :tabid: devtest
+
+      .. include:: /includes/shared-settings-clusters-devtest.rst
+
+   .. tab:: Staging and Prod Environments
+      :tabid: stagingprod
+
+      .. include:: /includes/shared-settings-clusters-stagingprod.rst
 
 .. tabs::
 
@@ -46,8 +56,8 @@ These examples also apply other recommended configurations, including:
 
       Content here
 
-   .. tab:: CDK
-      :tabid: CDK
+   .. tab:: CloudFormation
+      :tabid: CloudFormation
 
       Content here
 

--- a/source/backups.txt
+++ b/source/backups.txt
@@ -27,7 +27,17 @@ The following examples <perform this action> using |service|
 
 These examples also apply other recommended configurations, including:
 
-.. include:: /includes/shared-settings-clusters.rst
+.. tabs::
+
+   .. tab:: Dev and Test Environments
+      :tabid: devtest
+
+      .. include:: /includes/shared-settings-clusters-devtest.rst
+
+   .. tab:: Staging and Prod Environments
+      :tabid: stagingprod
+
+      .. include:: /includes/shared-settings-clusters-stagingprod.rst
 
 .. tabs::
 
@@ -46,8 +56,8 @@ These examples also apply other recommended configurations, including:
 
       Content here
 
-   .. tab:: CDK
-      :tabid: CDK
+   .. tab:: CloudFormation
+      :tabid: CloudFormation
 
       Content here
 

--- a/source/billing-data.txt
+++ b/source/billing-data.txt
@@ -27,7 +27,17 @@ The following examples <perform this action> using |service|
 
 These examples also apply other recommended configurations, including:
 
-.. include:: /includes/shared-settings-clusters.rst
+.. tabs::
+
+   .. tab:: Dev and Test Environments
+      :tabid: devtest
+
+      .. include:: /includes/shared-settings-clusters-devtest.rst
+
+   .. tab:: Staging and Prod Environments
+      :tabid: stagingprod
+
+      .. include:: /includes/shared-settings-clusters-stagingprod.rst
 
 .. tabs::
 
@@ -46,8 +56,8 @@ These examples also apply other recommended configurations, including:
 
       Content here
 
-   .. tab:: CDK
-      :tabid: CDK
+   .. tab:: CloudFormation
+      :tabid: CloudFormation
 
       Content here
 

--- a/source/cluster-config.txt
+++ b/source/cluster-config.txt
@@ -27,7 +27,17 @@ The following examples <perform this action> using |service|
 
 These examples also apply other recommended configurations, including:
 
-.. include:: /includes/shared-settings-clusters.rst
+.. tabs::
+
+   .. tab:: Dev and Test Environments
+      :tabid: devtest
+
+      .. include:: /includes/shared-settings-clusters-devtest.rst
+
+   .. tab:: Staging and Prod Environments
+      :tabid: stagingprod
+
+      .. include:: /includes/shared-settings-clusters-stagingprod.rst
 
 .. tabs::
 
@@ -46,8 +56,8 @@ These examples also apply other recommended configurations, including:
 
       Content here
 
-   .. tab:: CDK
-      :tabid: CDK
+   .. tab:: CloudFormation
+      :tabid: CloudFormation
 
       Content here
 

--- a/source/compliance.txt
+++ b/source/compliance.txt
@@ -27,7 +27,17 @@ The following examples <perform this action> using |service|
 
 These examples also apply other recommended configurations, including:
 
-.. include:: /includes/shared-settings-clusters.rst
+.. tabs::
+
+   .. tab:: Dev and Test Environments
+      :tabid: devtest
+
+      .. include:: /includes/shared-settings-clusters-devtest.rst
+
+   .. tab:: Staging and Prod Environments
+      :tabid: stagingprod
+
+      .. include:: /includes/shared-settings-clusters-stagingprod.rst
 
 .. tabs::
 
@@ -46,8 +56,8 @@ These examples also apply other recommended configurations, including:
 
       Content here
 
-   .. tab:: CDK
-      :tabid: CDK
+   .. tab:: CloudFormation
+      :tabid: CloudFormation
 
       Content here
 

--- a/source/data-encryption.txt
+++ b/source/data-encryption.txt
@@ -27,7 +27,17 @@ The following examples <perform this action> using |service|
 
 These examples also apply other recommended configurations, including:
 
-.. include:: /includes/shared-settings-clusters.rst
+.. tabs::
+
+   .. tab:: Dev and Test Environments
+      :tabid: devtest
+
+      .. include:: /includes/shared-settings-clusters-devtest.rst
+
+   .. tab:: Staging and Prod Environments
+      :tabid: stagingprod
+
+      .. include:: /includes/shared-settings-clusters-stagingprod.rst
 
 .. tabs::
 
@@ -46,8 +56,8 @@ These examples also apply other recommended configurations, including:
 
       Content here
 
-   .. tab:: CDK
-      :tabid: CDK
+   .. tab:: CloudFormation
+      :tabid: CloudFormation
 
       Content here
 

--- a/source/data-storage.txt
+++ b/source/data-storage.txt
@@ -27,7 +27,18 @@ The following examples <perform this action> using |service|
 
 These examples also apply other recommended configurations, including:
 
-.. include:: /includes/shared-settings-clusters.rst
+.. tabs::
+
+   .. tab:: Dev and Test Environments
+      :tabid: devtest
+
+      .. include:: /includes/shared-settings-clusters-devtest.rst
+
+   .. tab:: Staging and Prod Environments
+      :tabid: stagingprod
+
+      .. include:: /includes/shared-settings-clusters-stagingprod.rst
+         
 .. tabs::
 
    .. tab:: API
@@ -45,8 +56,8 @@ These examples also apply other recommended configurations, including:
 
       Content here
 
-   .. tab:: CDK
-      :tabid: CDK
+   .. tab:: CloudFormation
+      :tabid: CloudFormation
 
       Content here
 

--- a/source/getting-started.txt
+++ b/source/getting-started.txt
@@ -9,9 +9,12 @@ Use the following resources to get started with the
 
 - :ref:`Landing Zone Design <arch-center-landing-zone>`
 - :ref:`Migration <arch-center-migration>`
+- :ref:`Organization, Project, and Deployment Hierarchy
+  <arch-center-hierarchy>`
 
 .. toctree::
    :titlesonly:
 
    Landing Zone Design </landing-zone>
    Migration </migration>
+   Orgs, Projects, and Deployments </hierarchy>

--- a/source/hierarchy.txt
+++ b/source/hierarchy.txt
@@ -19,35 +19,116 @@ Intro statement
 
 Content here
 
+.. _arch-center-cluster-size-guide:
+
+Cluster Size Guide
+~~~~~~~~~~~~~~~~~~
+
 Examples
 --------
 
-The following examples <perform this action> using |service|
-:ref:`tools for automation <arch-center-automation>`.
+The following examples <perform this action> using |service| using 
+|service| :ref:`tools for automation <arch-center-automation>`.
 
-These examples also apply all recommended configurations, including:
+These examples also apply other recommended configurations, including:
 
-.. include:: /includes/shared-settings-clusters.rst
+.. tabs::
+
+   .. tab:: Dev and Test Environments
+      :tabid: devtest
+
+      .. include:: /includes/shared-settings-clusters-devtest.rst
+
+   .. tab:: Staging and Prod Environments
+      :tabid: stagingprod
+
+      .. include:: /includes/shared-settings-clusters-stagingprod.rst
 
 .. tabs::
 
    .. tab:: API
       :tabid: api
 
-      Content here
 
    .. tab:: CLI
       :tabid: cli
 
-      Content here
+      .. note::
+
+         Before you
+         can create resources with the {+atlas-cli+}, you must:
+
+         - :atlas:`Create your paying organization 
+           </billing/#configure-a-paying-organization>` and :atlas:`create an API key </configure-api-access/>` for the
+           paying organization.
+         - :atlascli:`Install the {+atlas-cli+} </install-atlas-cli/>` 
+         - :atlascli:`Connect from the {+atlas-cli+} 
+           </connect-atlas-cli/>` using the steps for :guilabel:`Programmatic Use`.
+
+      Create the Organizations
+      ~~~~~~~~~~~~~~~~~~~~~~~~
+
+      Run the following command for each business unit:
+
+      For more configuration options and info about this example, 
+      see :ref:`atlas-organizations-create`.
+
+      To get the user IDs and organization IDs, see the following
+      commands:
+
+      - :ref:`atlas-organizations-list`
+      - :ref:`atlas-organizations-users-list`
+
+      Create the Projects
+      ~~~~~~~~~~~~~~~~~~~
+
+      Run the following command for each application and environment pair:
+
+      .. include:: /includes/examples/cli-example-create-projects.rst
+
+      For more configuration options and info about this example, 
+      see :ref:`atlas-projects-create`.
+
+      To get the project IDs, see the following command:
+
+      - :ref:`atlas-projects-list`
+
+      Create One Deployment Per Project
+      ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+      .. tabs::
+
+         .. tab:: Dev and Test Environments
+            :tabid: devtest
+
+            For your development and testing environments, run the following command for each project that you created:
+
+            .. include:: /includes/examples/cli-example-create-clusters-devtest.rst
+
+         .. tab:: Staging and Prod Environments
+            :tabid: stagingprod
+
+            For your staging and production environments, create the following ``cluster.json`` file for each project that you
+            created:
+
+            .. include:: /includes/examples/cli-json-example-create-clusters.rst
+
+            After you create the ``cluster.json`` file, run the
+            following command for each project that you created. The
+            command uses the ``cluster.json`` file to create a cluster.
+
+            .. include:: /includes/examples/cli-example-create-clusters-stagingprod.rst 
+
+      For more configuration options and info about this example, 
+      see :ref:`atlas-clusters-create`.
 
    .. tab:: Terraform
       :tabid: Terraform
 
       Content here
 
-   .. tab:: CDK
-      :tabid: CDK
+   .. tab:: CloudFormation
+      :tabid: CloudFormation
 
       Content here
 

--- a/source/high-availability.txt
+++ b/source/high-availability.txt
@@ -27,7 +27,17 @@ The following examples <perform this action> using |service|
 
 These examples also apply other recommended configurations, including:
 
-.. include:: /includes/shared-settings-clusters.rst
+.. tabs::
+
+   .. tab:: Dev and Test Environments
+      :tabid: devtest
+
+      .. include:: /includes/shared-settings-clusters-devtest.rst
+
+   .. tab:: Staging and Prod Environments
+      :tabid: stagingprod
+
+      .. include:: /includes/shared-settings-clusters-stagingprod.rst
 
 .. tabs::
 
@@ -46,8 +56,8 @@ These examples also apply other recommended configurations, including:
 
       Content here
 
-   .. tab:: CDK
-      :tabid: CDK
+   .. tab:: CloudFormation
+      :tabid: CloudFormation
 
       Content here
 

--- a/source/includes/examples/cli-example-create-clusters-devtest.rst
+++ b/source/includes/examples/cli-example-create-clusters-devtest.rst
@@ -1,0 +1,14 @@
+.. code-block::
+   :copyable: true
+
+   atlas clusters create CustomerPortalDev \
+     --projectId 56fd11f25f23b33ef4c2a331 \
+     --region EASTERN_US \
+     --members 3 \
+     --tier M30 \
+     --provider GCP \
+     --mdbVersion 8.0 \
+     --diskSizeGB 30 \
+     --watch
+
+

--- a/source/includes/examples/cli-example-create-clusters-stagingprod.rst
+++ b/source/includes/examples/cli-example-create-clusters-stagingprod.rst
@@ -1,0 +1,6 @@
+.. code-block::
+   :copyable: true
+
+   atlas cluster create --projectId 5e2211c17a3e5a48f5497de3 --file cluster.json
+
+

--- a/source/includes/examples/cli-example-create-projects.rst
+++ b/source/includes/examples/cli-example-create-projects.rst
@@ -1,0 +1,6 @@
+.. code-block::
+   :copyable: true
+
+   atlas projects create "Customer Portal - Prod" --tag environment=production --orgId 32b6e34b3d91647abb20e7b8
+
+

--- a/source/includes/examples/cli-json-example-create-clusters.rst
+++ b/source/includes/examples/cli-json-example-create-clusters.rst
@@ -1,0 +1,114 @@
+.. code-block::
+   :copyable: true
+
+   {
+       "clusterType": "REPLICASET",
+       "links": [],
+       "name": "CustomerPortalProd",
+       "replicationSpecs": [
+         {
+           "numShards": 1,
+           "regionConfigs": [
+             {
+               "analyticsAutoScaling": {
+                 "autoIndexing": {
+                   "enabled": false
+                 },
+                 "compute": {
+                   "enabled": true,
+                   "maxInstanceSize": "M40",
+                   "minInstanceSize": "M30",
+                   "scaleDownEnabled": true
+                 },
+                 "diskGB": {
+                   "enabled": true
+                 }
+               },
+               "analyticsSpecs": {
+                 "instanceSize": "M30",
+                 "nodeCount": 0
+               },
+               "autoScaling": {
+                 "autoIndexing": {
+                   "enabled": false
+                 },
+                 "compute": {
+                   "enabled": true,
+                   "maxInstanceSize": "M40",
+                   "minInstanceSize": "M30",
+                   "scaleDownEnabled": true
+                 },
+                 "diskGB": {
+                   "enabled": true
+                 }
+               },
+               "electableSpecs": {
+                 "instanceSize": "M30",
+                 "nodeCount": 3
+               },
+               "hiddenSecondarySpecs": {
+                 "instanceSize": "M30",
+                 "nodeCount": 0
+               },
+               "priority": 7,
+               "providerName": "AWS",
+               "readOnlySpecs": {
+                 "instanceSize": "M30",
+                 "nodeCount": 0
+               },
+               "regionName": "US_EAST_1"
+             },
+             {
+               "analyticsAutoScaling": {
+                 "autoIndexing": {
+                   "enabled": false
+                 },
+                 "compute": {
+                   "enabled": true,
+                   "maxInstanceSize": "M40",
+                   "minInstanceSize": "M30",
+                   "scaleDownEnabled": true
+                 },
+                 "diskGB": {
+                   "enabled": true
+                 }
+               },
+               "analyticsSpecs": {
+                 "instanceSize": "M30",
+                 "nodeCount": 0
+               },
+               "autoScaling": {
+                 "autoIndexing": {
+                   "enabled": false
+                 },
+                 "compute": {
+                   "enabled": true,
+                   "maxInstanceSize": "M40",
+                   "minInstanceSize": "M30",
+                   "scaleDownEnabled": true
+                 },
+                 "diskGB": {
+                   "enabled": true
+                 }
+               },
+               "electableSpecs": {
+                 "instanceSize": "M30",
+                 "nodeCount": 2
+               },
+               "hiddenSecondarySpecs": {
+                 "instanceSize": "M30",
+                 "nodeCount": 0
+               },
+               "priority": 6,
+               "providerName": "GCP",
+               "readOnlySpecs": {
+                 "instanceSize": "M30",
+                 "nodeCount": 0
+               },
+               "regionName": "EASTERN_US"
+             }
+           ],
+           "zoneName": "Zone 1"
+         }
+       ]
+   }

--- a/source/includes/shared-settings-clusters-devtest.rst
+++ b/source/includes/shared-settings-clusters-devtest.rst
@@ -1,0 +1,8 @@
+- Backup and autoscaling disabled to conserve costs.
+- Termination protection disabled. We recommend terminating clusters
+  after seven days of inactivity to conserve costs.
+- Cluster tier set to ``M30`` for a medium size application. Use the
+  :ref:`cluster size guide <arch-center-cluster-size-guide>` to learn
+  the recommended cluster tier for your application size.
+     
+

--- a/source/includes/shared-settings-clusters-stagingprod.rst
+++ b/source/includes/shared-settings-clusters-stagingprod.rst
@@ -1,0 +1,5 @@
+- :ref:`{+Cluster+} autoscaling <arch-center-scalability>` enabled.
+- Cluster tier set to ``M30`` for a medium size application. Use the
+  :ref:`cluster size guide <arch-center-cluster-size-guide>` to learn
+  the recommended cluster tier for your application size.
+

--- a/source/includes/shared-settings-clusters.rst
+++ b/source/includes/shared-settings-clusters.rst
@@ -1,4 +1,0 @@
-- :ref:`Multi-cloud and multi-region deployments
-  <arch-center-multi-cloud-region>`
-- :ref:`{+Cluster+} autoscaling <arch-center-scalability>`
-

--- a/source/monitoring-alerts.txt
+++ b/source/monitoring-alerts.txt
@@ -27,7 +27,17 @@ The following examples <perform this action> using |service|
 
 These examples also apply other recommended configurations, including:
 
-.. include:: /includes/shared-settings-clusters.rst
+.. tabs::
+
+   .. tab:: Dev and Test Environments
+      :tabid: devtest
+
+      .. include:: /includes/shared-settings-clusters-devtest.rst
+
+   .. tab:: Staging and Prod Environments
+      :tabid: stagingprod
+
+      .. include:: /includes/shared-settings-clusters-stagingprod.rst
 
 .. tabs::
 
@@ -46,8 +56,8 @@ These examples also apply other recommended configurations, including:
 
       Content here
 
-   .. tab:: CDK
-      :tabid: CDK
+   .. tab:: CloudFormation
+      :tabid: CloudFormation
 
       Content here
 

--- a/source/multi-cloud-multi-region.txt
+++ b/source/multi-cloud-multi-region.txt
@@ -27,7 +27,17 @@ The following examples <perform this action> using |service|
 
 These examples also apply other recommended configurations, including:
 
-.. include:: /includes/shared-settings-clusters.rst
+.. tabs::
+
+   .. tab:: Dev and Test Environments
+      :tabid: devtest
+
+      .. include:: /includes/shared-settings-clusters-devtest.rst
+
+   .. tab:: Staging and Prod Environments
+      :tabid: stagingprod
+
+      .. include:: /includes/shared-settings-clusters-stagingprod.rst
 
 .. tabs::
 
@@ -46,8 +56,8 @@ These examples also apply other recommended configurations, including:
 
       Content here
 
-   .. tab:: CDK
-      :tabid: CDK
+   .. tab:: CloudFormation
+      :tabid: CloudFormation
 
       Content here
 

--- a/source/network-security.txt
+++ b/source/network-security.txt
@@ -27,7 +27,17 @@ The following examples <perform this action> using |service|
 
 These examples also apply other recommended configurations, including:
 
-.. include:: /includes/shared-settings-clusters.rst
+.. tabs::
+
+   .. tab:: Dev and Test Environments
+      :tabid: devtest
+
+      .. include:: /includes/shared-settings-clusters-devtest.rst
+
+   .. tab:: Staging and Prod Environments
+      :tabid: stagingprod
+
+      .. include:: /includes/shared-settings-clusters-stagingprod.rst
 
 .. tabs::
 
@@ -46,8 +56,8 @@ These examples also apply other recommended configurations, including:
 
       Content here
 
-   .. tab:: CDK
-      :tabid: CDK
+   .. tab:: CloudFormation
+      :tabid: CloudFormation
 
       Content here
 

--- a/source/resiliency.txt
+++ b/source/resiliency.txt
@@ -27,7 +27,17 @@ The following examples <perform this action> using |service|
 
 These examples also apply other recommended configurations, including:
 
-.. include:: /includes/shared-settings-clusters.rst
+.. tabs::
+
+   .. tab:: Dev and Test Environments
+      :tabid: devtest
+
+      .. include:: /includes/shared-settings-clusters-devtest.rst
+
+   .. tab:: Staging and Prod Environments
+      :tabid: stagingprod
+
+      .. include:: /includes/shared-settings-clusters-stagingprod.rst
 
 .. tabs::
 
@@ -46,8 +56,8 @@ These examples also apply other recommended configurations, including:
 
       Content here
 
-   .. tab:: CDK
-      :tabid: CDK
+   .. tab:: CloudFormation
+      :tabid: CloudFormation
 
       Content here
 

--- a/source/scalability.txt
+++ b/source/scalability.txt
@@ -27,7 +27,17 @@ The following examples <perform this action> using |service|
 
 These examples also apply other recommended configurations, including:
 
-.. include:: /includes/shared-settings-clusters.rst
+.. tabs::
+
+   .. tab:: Dev and Test Environments
+      :tabid: devtest
+
+      .. include:: /includes/shared-settings-clusters-devtest.rst
+
+   .. tab:: Staging and Prod Environments
+      :tabid: stagingprod
+
+      .. include:: /includes/shared-settings-clusters-stagingprod.rst
 
 .. tabs::
 
@@ -46,8 +56,8 @@ These examples also apply other recommended configurations, including:
 
       Content here
 
-   .. tab:: CDK
-      :tabid: CDK
+   .. tab:: CloudFormation
+      :tabid: CloudFormation
 
       Content here
 

--- a/source/security.txt
+++ b/source/security.txt
@@ -6,8 +6,6 @@ Security
 
 Use the following resources to learn about security in {+service+}:
 
-- :ref:`Organization, Project, and Deployment Hierarchy
-  <arch-center-hierarchy>`
 - :ref:`Network Security <arch-center-network-security>`
 - :ref:`Authorization and Authentication <arch-center-auth>`
 - :ref:`Data Encryption <arch-center-data-encryption>`
@@ -17,7 +15,6 @@ Use the following resources to learn about security in {+service+}:
 .. toctree::
    :titlesonly:
 
-   Orgs, Projects, and Deployments </hierarchy>
    Network Security </network-security>
    Authorization and Authentication </auth>
    Data Encryption </data-encryption>


### PR DESCRIPTION
[DOCSP](https://jira.mongodb.org/browse/DOCSP-43341)- CLI code sections only in this PR
[STAGING](https://deploy-preview-5--docs-atlas-architecture.netlify.app/hierarchy/#examples)

Aside from adding code examples, this PR: 

- Moves the Org, Project, and Deployment Hierarchy page to Getting Started per Andrew D's feedback. I'll write the intro to frame this as info that applies across pillars and helps users get started with Atlas.
- Adds environment-specific shared setting files since we'll have environment-specific code examples.
- Replaces CDK typo with CloudFormation on tabs

**All commands successfully tested, results below:**

CLI- cluster create: dev/test:
![Screenshot 2024-10-08 at 8 24 07 AM](https://github.com/user-attachments/assets/69426f5e-eb1e-4246-9b90-7e964ca24b29)

CLI- cluster create: staging/prod:
![Screenshot 2024-10-08 at 7 59 31 AM](https://github.com/user-attachments/assets/50386efc-9d38-4d2c-a286-81ed80719278)
![Screenshot 2024-10-08 at 7 59 47 AM](https://github.com/user-attachments/assets/dceb7b63-e499-45b6-bb0b-71a1af6aa543)

CLI- project create:
![Screenshot 2024-10-08 at 8 02 56 AM](https://github.com/user-attachments/assets/d8c4c382-0d72-41e8-a02f-5c9d76a63b2c)

CLI- org create- removed for now, need paying org set up to successfully execute this command using API tokens. I'll add it back when I can successfully test.


