### PR TITLE
(DOCSP-44262) Adds Terraform examples for projects and clusters

### DIFF
--- a/source/hierarchy.txt
+++ b/source/hierarchy.txt
@@ -82,7 +82,7 @@ These examples also apply other recommended configurations, including:
       Create the Projects
       ~~~~~~~~~~~~~~~~~~~
 
-      Run the following command for each application and environment pair:
+      Run the following command for each application and environment pair. Change the IDs and names to use your values:
 
       .. include:: /includes/examples/cli-example-create-projects.rst
 
@@ -101,7 +101,8 @@ These examples also apply other recommended configurations, including:
          .. tab:: Dev and Test Environments
             :tabid: devtest
 
-            For your development and testing environments, run the following command for each project that you created:
+            For your development and testing environments, run the following command for each project that you created. Change
+            the IDs and names to use your values:
 
             .. include:: /includes/examples/cli-example-create-clusters-devtest.rst
 
@@ -109,7 +110,7 @@ These examples also apply other recommended configurations, including:
             :tabid: stagingprod
 
             For your staging and production environments, create the following ``cluster.json`` file for each project that you
-            created:
+            created. Change the IDs and names to use your values:
 
             .. include:: /includes/examples/cli-json-example-create-clusters.rst
 
@@ -125,7 +126,134 @@ These examples also apply other recommended configurations, including:
    .. tab:: Terraform
       :tabid: Terraform
 
-      Content here
+      .. note::
+
+         Before you
+         can create resources with Terraform, you must:
+
+         - :atlas:`Create your paying organization 
+           </billing/#configure-a-paying-organization>` and :atlas:`create an API key </configure-api-access/>` for the
+           paying organization. Store your API key as environment
+           variables by running the following command in the terminal:
+
+           .. code-block::
+
+              export MONGODB_ATLAS_PUBLIC_KEY="<insert your public key here>"
+              export MONGODB_ATLAS_PRIVATE_KEY="<insert your private key here>"
+
+         - `Install Terraform 
+           <https://developer.hashicorp.com/terraform/tutorials/aws-get-started/install-cli>`__ 
+
+      Create the Projects and Deployments
+      ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+      .. tabs::
+
+         .. tab:: Dev and Test Environments
+            :tabid: devtest
+
+            For your development and testing environments, create the
+            following files for each application and environment 
+            pair. Place the files for each application and environment
+            pair in their own directory. Change the IDs and names to use your values:
+
+            main.tf
+            ```````
+
+            .. include:: /includes/examples/tf-example-main-devtest.rst 
+
+            variables.tf
+            ````````````
+
+            .. include:: /includes/examples/tf-example-variables.rst
+
+            terraform.tfvars
+            ````````````````
+
+            .. include:: /includes/examples/tf-example-tfvars-devtest.rst
+
+            provider.tf
+            ```````````
+
+            .. include:: /includes/examples/tf-example-provider.rst
+
+            After you create the files, navigate to each application and environment pair's directory and run the following
+            command to initialize Terraform:
+
+            .. code-block::
+
+               terraform init
+
+            Run the following command to view the Terraform plan:
+
+            .. code-block::
+
+               terraform plan
+            
+            Run the following command to create one project and one deployment for the application and environment pair. The command uses the files and the |service-terraform| to
+            create the projects and clusters:
+
+            .. code-block::
+
+               terraform apply
+
+            When prompted, type ``yes`` and press :kbd:`Enter` to apply
+            the configuration.
+
+         .. tab:: Staging and Prod Environments
+            :tabid: stagingprod
+
+            For your staging and production environments, create the
+            following files for each application and environment 
+            pair. Place the files for each application and environment
+            pair in their own directory. Change the IDs and names to use your values:
+
+            main.tf
+            ```````
+
+            .. include:: /includes/examples/tf-example-main-stagingprod.rst 
+
+            variables.tf
+            ````````````
+
+            .. include:: /includes/examples/tf-example-variables.rst
+
+            terraform.tfvars
+            ````````````````
+
+            .. include:: /includes/examples/tf-example-tfvars-stagingprod.rst
+
+            provider.tf
+            ```````````
+
+            .. include:: /includes/examples/tf-example-provider.rst
+
+            After you create the files, navigate to each application and environment pair's directory and run the following
+            command to initialize Terraform:
+
+            .. code-block::
+
+               terraform init
+
+            Run the following command to view the Terraform plan:
+
+            .. code-block::
+
+               terraform plan
+            
+            Run the following command to create one project and one deployment for the application and environment pair. The command uses the files and the |service-terraform| to
+            create the projects and clusters:
+
+            .. code-block::
+
+               terraform apply
+
+            When prompted, type ``yes`` and press :kbd:`Enter` to apply
+            the configuration. 
+      
+      For more configuration options and info about this example, 
+      see |service-terraform| and the `MongoDB Terraform Blog Post
+      <https://www.mongodb.com/developer/products/atlas/deploy-mongodb-atlas-terraform-aws/>`__.
 
    .. tab:: CloudFormation
       :tabid: CloudFormation

--- a/source/includes/examples/tf-example-main-devtest.rst
+++ b/source/includes/examples/tf-example-main-devtest.rst
@@ -1,0 +1,35 @@
+.. code-block::
+   :copyable: true
+
+   # Create a Project
+   resource "mongodbatlas_project" "atlas-project" {
+     org_id = var.atlas_org_id
+     name = var.atlas_project_name
+   }
+   
+   # Create an Atlas Advanced Cluster 
+   resource "mongodbatlas_advanced_cluster" "atlas-cluster" {
+     project_id = mongodbatlas_project.atlas-project.id
+     name = "ClusterPortalDev"
+     cluster_type = "REPLICASET"
+     mongo_db_major_version = var.mongodb_version
+     replication_specs {
+       region_configs {
+         electable_specs {
+           instance_size = var.cluster_instance_size_name
+           node_count    = 3
+         }
+         analytics_specs {
+           instance_size = var.cluster_instance_size_name
+           node_count    = 1
+         }
+         priority      = 7
+         provider_name = var.cloud_provider
+         region_name   = var.atlas_region
+       }
+     }
+   }
+   
+   # Outputs to Display
+   output "atlas_cluster_connection_string" { value = mongodbatlas_advanced_cluster.atlas-cluster.connection_strings.0.standard_srv }
+   output "project_name"      { value = mongodbatlas_project.atlas-project.name }

--- a/source/includes/examples/tf-example-main-stagingprod.rst
+++ b/source/includes/examples/tf-example-main-stagingprod.rst
@@ -1,0 +1,35 @@
+.. code-block::
+   :copyable: true
+
+   # Create a Project
+   resource "mongodbatlas_project" "atlas-project" {
+     org_id = var.atlas_org_id
+     name = var.atlas_project_name
+   }
+   
+   # Create an Atlas Advanced Cluster 
+   resource "mongodbatlas_advanced_cluster" "atlas-cluster" {
+     project_id = mongodbatlas_project.atlas-project.id
+     name = "ClusterPortalProd"
+     cluster_type = "REPLICASET"
+     mongo_db_major_version = var.mongodb_version
+     replication_specs {
+       region_configs {
+         electable_specs {
+           instance_size = var.cluster_instance_size_name
+           node_count    = 3
+         }
+         analytics_specs {
+           instance_size = var.cluster_instance_size_name
+           node_count    = 1
+         }
+         priority      = 7
+         provider_name = var.cloud_provider
+         region_name   = var.atlas_region
+       }
+     }
+   }
+   
+   # Outputs to Display
+   output "atlas_cluster_connection_string" { value = mongodbatlas_advanced_cluster.atlas-cluster.connection_strings.0.standard_srv }
+   output "project_name"      { value = mongodbatlas_project.atlas-project.name }

--- a/source/includes/examples/tf-example-provider.rst
+++ b/source/includes/examples/tf-example-provider.rst
@@ -1,0 +1,12 @@
+.. code-block::
+   :copyable: true
+
+   # Define the MongoDB Atlas Provider
+   terraform {
+     required_providers {
+       mongodbatlas = {
+         source = "mongodb/mongodbatlas"
+       }
+     }
+     required_version = ">= 0.13"
+   }

--- a/source/includes/examples/tf-example-tfvars-devtest.rst
+++ b/source/includes/examples/tf-example-tfvars-devtest.rst
@@ -1,0 +1,10 @@
+.. code-block::
+   :copyable: true
+
+   atlas_org_id = "32b6e34b3d91647abb20e7b8"
+   atlas_project_name = "Customer Portal - Dev"
+   environment = "dev"
+   cluster_instance_size_name = "M30"
+   cloud_provider = "AWS"
+   atlas_region = "US_WEST_2"
+   mongodb_version = "8.0"

--- a/source/includes/examples/tf-example-tfvars-stagingprod.rst
+++ b/source/includes/examples/tf-example-tfvars-stagingprod.rst
@@ -1,0 +1,10 @@
+.. code-block::
+   :copyable: true
+
+   atlas_org_id = "32b6e34b3d91647abb20e7b8"
+   atlas_project_name = "Customer Portal - Prod"
+   environment = "prod"
+   cluster_instance_size_name = "M30"
+   cloud_provider = "AWS"
+   atlas_region = "US_WEST_2"
+   mongodb_version = "8.0"

--- a/source/includes/examples/tf-example-variables.rst
+++ b/source/includes/examples/tf-example-variables.rst
@@ -1,0 +1,43 @@
+.. code-block::
+   :copyable: true
+
+   # Atlas Organization ID 
+   variable "atlas_org_id" {
+     type        = string
+     description = "Atlas Organization ID"
+   }
+   # Atlas Project Name
+   variable "atlas_project_name" {
+     type        = string
+     description = "Atlas Project Name"
+   }
+   
+   # Atlas Project Environment
+   variable "environment" {
+     type        = string
+     description = "The environment to be built"
+   }
+   
+   # Cluster Instance Size Name 
+   variable "cluster_instance_size_name" {
+     type        = string
+     description = "Cluster instance size name"
+   }
+   
+   # Cloud Provider to Host Atlas Cluster
+   variable "cloud_provider" {
+     type        = string
+     description = "AWS or GCP or Azure"
+   }
+   
+   # Atlas Region
+   variable "atlas_region" {
+     type        = string
+     description = "Atlas region where resources will be created"
+   }
+   
+   # MongoDB Version 
+   variable "mongodb_version" {
+     type        = string
+     description = "MongoDB Version"
+   }

--- a/source/includes/shared-settings-clusters-devtest.rst
+++ b/source/includes/shared-settings-clusters-devtest.rst
@@ -2,5 +2,10 @@
 - Cluster tier set to ``M30`` for a medium-sized application. Use the
   :ref:`cluster size guide <arch-center-cluster-size-guide>` to learn
   the recommended cluster tier for your application size.
+
+Our examples use |aws|, |azure|, and {+gcp+}
+interchangeably. You can use any of these three cloud providers, but
+you must change the region name to match the cloud provider. To learn about the cloud providers and their regions, see 
+:atlas:`Cloud Providers </reference/cloud-providers/>`.
      
 

--- a/source/includes/shared-settings-clusters-stagingprod.rst
+++ b/source/includes/shared-settings-clusters-stagingprod.rst
@@ -2,3 +2,8 @@
   :ref:`cluster size guide <arch-center-cluster-size-guide>` to learn
   the recommended cluster tier for your application size.
 
+Our examples use |aws|, |azure|, and {+gcp+}
+interchangeably. You can use any of these three cloud providers, but
+you must change the region name to match the cloud provider. To learn about the cloud providers and their regions, see 
+:atlas:`Cloud Providers </reference/cloud-providers/>`.
+


### PR DESCRIPTION
Adds basic TF examples for creating projects and clusters. Orgs will be added later once I set up cross-org billing. Note that recommendations will be added to these by writers in future PRs; this is just the basics for creation.

[DOCSP](https://jira.mongodb.org/browse/DOCSP-44262)
[STAGING](https://deploy-preview-10--docs-atlas-architecture.netlify.app/hierarchy/#examples) - Terraform tab

I have tested these and confirmed they work, see screenshots below:
![Screenshot 2024-10-14 at 9 34 24 AM](https://github.com/user-attachments/assets/8a11bf8e-bfd0-4bf8-8c0b-98f3ea1be745)
![Screenshot 2024-10-14 at 9 35 02 AM](https://github.com/user-attachments/assets/3ae7c988-3a72-4641-b11c-16fee5096ecc)
