### PR TITLE
Removes extra tabs from code examples we won't include

### DIFF
--- a/source/auditing-logging.txt
+++ b/source/auditing-logging.txt
@@ -39,11 +39,6 @@ The following examples <perform this action> using |service|
 
 .. tabs::
 
-   .. tab:: API
-      :tabid: api
-
-      Content here
-
    .. tab:: CLI
       :tabid: cli
 
@@ -51,16 +46,6 @@ The following examples <perform this action> using |service|
 
    .. tab:: Terraform
       :tabid: Terraform
-
-      Content here
-
-   .. tab:: CloudFormation
-      :tabid: CloudFormation
-
-      Content here
-
-   .. tab:: AKO
-      :tabid: ako
 
       Content here
 

--- a/source/auth.txt
+++ b/source/auth.txt
@@ -41,11 +41,6 @@ These examples also apply other recommended configurations, including:
 
 .. tabs::
 
-   .. tab:: API
-      :tabid: api
-
-      Content here
-
    .. tab:: CLI
       :tabid: cli
 
@@ -53,16 +48,6 @@ These examples also apply other recommended configurations, including:
 
    .. tab:: Terraform
       :tabid: Terraform
-
-      Content here
-
-   .. tab:: CloudFormation
-      :tabid: CloudFormation
-
-      Content here
-
-   .. tab:: AKO
-      :tabid: ako
 
       Content here
 

--- a/source/automation.txt
+++ b/source/automation.txt
@@ -41,11 +41,6 @@ These examples also apply other recommended configurations, including:
 
 .. tabs::
 
-   .. tab:: API
-      :tabid: api
-
-      Content here
-
    .. tab:: CLI
       :tabid: cli
 
@@ -53,16 +48,6 @@ These examples also apply other recommended configurations, including:
 
    .. tab:: Terraform
       :tabid: Terraform
-
-      Content here
-
-   .. tab:: CloudFormation
-      :tabid: CloudFormation
-
-      Content here
-
-   .. tab:: AKO
-      :tabid: ako
 
       Content here
 

--- a/source/backup-transfer-query-config.txt
+++ b/source/backup-transfer-query-config.txt
@@ -41,11 +41,6 @@ These examples also apply other recommended configurations, including:
 
 .. tabs::
 
-   .. tab:: API
-      :tabid: api
-
-      Content here
-
    .. tab:: CLI
       :tabid: cli
 
@@ -53,16 +48,6 @@ These examples also apply other recommended configurations, including:
 
    .. tab:: Terraform
       :tabid: Terraform
-
-      Content here
-
-   .. tab:: CloudFormation
-      :tabid: CloudFormation
-
-      Content here
-
-   .. tab:: AKO
-      :tabid: ako
 
       Content here
 

--- a/source/backups.txt
+++ b/source/backups.txt
@@ -41,11 +41,6 @@ These examples also apply other recommended configurations, including:
 
 .. tabs::
 
-   .. tab:: API
-      :tabid: api
-
-      Content here
-
    .. tab:: CLI
       :tabid: cli
 
@@ -53,16 +48,6 @@ These examples also apply other recommended configurations, including:
 
    .. tab:: Terraform
       :tabid: Terraform
-
-      Content here
-
-   .. tab:: CloudFormation
-      :tabid: CloudFormation
-
-      Content here
-
-   .. tab:: AKO
-      :tabid: ako
 
       Content here
 

--- a/source/billing-data.txt
+++ b/source/billing-data.txt
@@ -41,11 +41,6 @@ These examples also apply other recommended configurations, including:
 
 .. tabs::
 
-   .. tab:: API
-      :tabid: api
-
-      Content here
-
    .. tab:: CLI
       :tabid: cli
 
@@ -53,16 +48,6 @@ These examples also apply other recommended configurations, including:
 
    .. tab:: Terraform
       :tabid: Terraform
-
-      Content here
-
-   .. tab:: CloudFormation
-      :tabid: CloudFormation
-
-      Content here
-
-   .. tab:: AKO
-      :tabid: ako
 
       Content here
 

--- a/source/cluster-config.txt
+++ b/source/cluster-config.txt
@@ -41,11 +41,6 @@ These examples also apply other recommended configurations, including:
 
 .. tabs::
 
-   .. tab:: API
-      :tabid: api
-
-      Content here
-
    .. tab:: CLI
       :tabid: cli
 
@@ -55,14 +50,3 @@ These examples also apply other recommended configurations, including:
       :tabid: Terraform
 
       Content here
-
-   .. tab:: CloudFormation
-      :tabid: CloudFormation
-
-      Content here
-
-   .. tab:: AKO
-      :tabid: ako
-
-      Content here
-

--- a/source/compliance.txt
+++ b/source/compliance.txt
@@ -41,11 +41,6 @@ These examples also apply other recommended configurations, including:
 
 .. tabs::
 
-   .. tab:: API
-      :tabid: api
-
-      Content here
-
    .. tab:: CLI
       :tabid: cli
 
@@ -53,16 +48,6 @@ These examples also apply other recommended configurations, including:
 
    .. tab:: Terraform
       :tabid: Terraform
-
-      Content here
-
-   .. tab:: CloudFormation
-      :tabid: CloudFormation
-
-      Content here
-
-   .. tab:: AKO
-      :tabid: ako
 
       Content here
 

--- a/source/data-encryption.txt
+++ b/source/data-encryption.txt
@@ -41,11 +41,6 @@ These examples also apply other recommended configurations, including:
 
 .. tabs::
 
-   .. tab:: API
-      :tabid: api
-
-      Content here
-
    .. tab:: CLI
       :tabid: cli
 
@@ -53,16 +48,6 @@ These examples also apply other recommended configurations, including:
 
    .. tab:: Terraform
       :tabid: Terraform
-
-      Content here
-
-   .. tab:: CloudFormation
-      :tabid: CloudFormation
-
-      Content here
-
-   .. tab:: AKO
-      :tabid: ako
 
       Content here
 

--- a/source/data-storage.txt
+++ b/source/data-storage.txt
@@ -41,11 +41,6 @@ These examples also apply other recommended configurations, including:
          
 .. tabs::
 
-   .. tab:: API
-      :tabid: api
-
-      Content here
-
    .. tab:: CLI
       :tabid: cli
 
@@ -53,16 +48,6 @@ These examples also apply other recommended configurations, including:
 
    .. tab:: Terraform
       :tabid: Terraform
-
-      Content here
-
-   .. tab:: CloudFormation
-      :tabid: CloudFormation
-
-      Content here
-
-   .. tab:: AKO
-      :tabid: ako
 
       Content here
 

--- a/source/hierarchy.txt
+++ b/source/hierarchy.txt
@@ -46,10 +46,6 @@ These examples also apply other recommended configurations, including:
 
 .. tabs::
 
-   .. tab:: API
-      :tabid: api
-
-
    .. tab:: CLI
       :tabid: cli
 
@@ -124,16 +120,6 @@ These examples also apply other recommended configurations, including:
 
    .. tab:: Terraform
       :tabid: Terraform
-
-      Content here
-
-   .. tab:: CloudFormation
-      :tabid: CloudFormation
-
-      Content here
-
-   .. tab:: AKO
-      :tabid: ako
 
       Content here
 

--- a/source/high-availability.txt
+++ b/source/high-availability.txt
@@ -41,11 +41,6 @@ These examples also apply other recommended configurations, including:
 
 .. tabs::
 
-   .. tab:: API
-      :tabid: api
-
-      Content here
-
    .. tab:: CLI
       :tabid: cli
 
@@ -55,14 +50,3 @@ These examples also apply other recommended configurations, including:
       :tabid: Terraform
 
       Content here
-
-   .. tab:: CloudFormation
-      :tabid: CloudFormation
-
-      Content here
-
-   .. tab:: AKO
-      :tabid: ako
-
-      Content here
-

--- a/source/monitoring-alerts.txt
+++ b/source/monitoring-alerts.txt
@@ -41,11 +41,6 @@ These examples also apply other recommended configurations, including:
 
 .. tabs::
 
-   .. tab:: API
-      :tabid: api
-
-      Content here
-
    .. tab:: CLI
       :tabid: cli
 
@@ -53,16 +48,6 @@ These examples also apply other recommended configurations, including:
 
    .. tab:: Terraform
       :tabid: Terraform
-
-      Content here
-
-   .. tab:: CloudFormation
-      :tabid: CloudFormation
-
-      Content here
-
-   .. tab:: AKO
-      :tabid: ako
 
       Content here
 

--- a/source/network-security.txt
+++ b/source/network-security.txt
@@ -41,11 +41,6 @@ These examples also apply other recommended configurations, including:
 
 .. tabs::
 
-   .. tab:: API
-      :tabid: api
-
-      Content here
-
    .. tab:: CLI
       :tabid: cli
 
@@ -53,16 +48,6 @@ These examples also apply other recommended configurations, including:
 
    .. tab:: Terraform
       :tabid: Terraform
-
-      Content here
-
-   .. tab:: CloudFormation
-      :tabid: CloudFormation
-
-      Content here
-
-   .. tab:: AKO
-      :tabid: ako
 
       Content here
 

--- a/source/resiliency.txt
+++ b/source/resiliency.txt
@@ -41,11 +41,6 @@ These examples also apply other recommended configurations, including:
 
 .. tabs::
 
-   .. tab:: API
-      :tabid: api
-
-      Content here
-
    .. tab:: CLI
       :tabid: cli
 
@@ -53,16 +48,6 @@ These examples also apply other recommended configurations, including:
 
    .. tab:: Terraform
       :tabid: Terraform
-
-      Content here
-
-   .. tab:: CloudFormation
-      :tabid: CloudFormation
-
-      Content here
-
-   .. tab:: AKO
-      :tabid: ako
 
       Content here
 

--- a/source/scalability.txt
+++ b/source/scalability.txt
@@ -41,11 +41,6 @@ These examples also apply other recommended configurations, including:
 
 .. tabs::
 
-   .. tab:: API
-      :tabid: api
-
-      Content here
-
    .. tab:: CLI
       :tabid: cli
 
@@ -53,16 +48,6 @@ These examples also apply other recommended configurations, including:
 
    .. tab:: Terraform
       :tabid: Terraform
-
-      Content here
-
-   .. tab:: CloudFormation
-      :tabid: CloudFormation
-
-      Content here
-
-   .. tab:: AKO
-      :tabid: ako
 
       Content here
 


### PR DESCRIPTION
Per discussion with PMs, we won't include API, AKO, or CloudFormation examples for MVP.