### PR TITLE
DOCSP-43352 added cost optimization page

### DIFF
--- a/source/cost-saving-config.txt
+++ b/source/cost-saving-config.txt
@@ -6,47 +6,56 @@ Cost-Saving Configurations
 
 .. default-domain:: mongodb
 
+.. facet::
+   :name: genre
+   :values: reference
+
+.. meta::
+   :keywords: atlas architecture center
+   :description: Learn about ways optimize your costs while using Atlas.
+
 .. contents:: On this page
    :local:
    :backlinks: none
-   :depth: 1
+   :depth: 2
    :class: onecol
 
-Intro statement
+|service-fullname| offers comprehensive tools and features to
+effectively manage and control an organization's database costs,
+especially as your usage expands. By providing detailed insights and
+user friendly cost optimization features, {+service+} enables you to
+better understand and streamline your spending.  
 
 {+service+} Features and Best Practices for Cost-Saving Configurations
 ----------------------------------------------------------------------
 
-Content here
+.. include:: /includes/billing-optimizations.rst
 
-Examples
---------
+Auto-Scaling {+Clusters+}
+~~~~~~~~~~~~~~~~~~~~~~~~~
 
-The following examples <perform this action> using |service|
-:ref:`tools for automation <arch-center-automation>`.
+{+service+} offers {+cluster+} auto-scaling for all tiers except the
+highest tier, specifically under the general and low-CPU classes.
 
-These examples also apply other recommended configurations, including:
+:ref:`Cluster auto-scaling <cluster-autoscaling>` enables {+clusters+}
+to automatically adjust the tier, storage capacity, or both, in response
+to real-time usage, helping users to maintain optimal performance
+without manual intervention. {+service+} analyzes the CPU utilization
+and memory utilization to determine when and whether to scale the
+{+cluster+} tier up or down.
 
-.. tabs::
+Users can also specify a range of maximum and minimum {+cluster+} sizes
+that their {+cluster+} can automatically scale to. {+service+} won't
+scale a {+cluster+} if the new tier falls outside a user's specified
+size range or if memory usage would exceed the capacity of the new tier.
+To learn more about {+cluster+} sizes, see
+:ref:`arch-center-cluster-size-guide`.
 
-   .. tab:: Dev and Test Environments
-      :tabid: devtest
+Billing Quota Management
+~~~~~~~~~~~~~~~~~~~~~~~~
 
-      .. include:: /includes/shared-settings-clusters-devtest.rst
-
-   .. tab:: Staging and Prod Environments
-      :tabid: stagingprod
-
-      .. include:: /includes/shared-settings-clusters-stagingprod.rst
-
-.. tabs::
-
-   .. tab:: CLI
-      :tabid: cli
-
-      Content here
-
-   .. tab:: Terraform
-      :tabid: Terraform
-
-      Content here
+|service| offers real-time notifications when spending nears or exceeds
+set thresholds. You can customize these alerts to be project-specific or
+team-specific, allowing for precise monitoring and control over
+different areas of cloud expenditure. To configure billing alerts, see
+:ref:`configure-alerts`.

--- a/source/includes/billing-optimizations.rst
+++ b/source/includes/billing-optimizations.rst
@@ -1,0 +1,85 @@
+Consider these strategies for optimizing your |service| costs.
+
+Underutilized {+Clusters+}
+~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+- Use :ref:`auto-scaling <cluster-autoscaling>` for both {+cluster+} tier and storage to 
+  match your usage and prevent over-provisioning.
+
+- For {+dedicated-clusters+}, consider scaling down 
+  to a lower tier or :ref:`pausing <pause-terminate-cluster>` the {+cluster+} 
+  if you won't use it for an extended period.
+
+High Backup Frequency
+~~~~~~~~~~~~~~~~~~~~~
+
+- If :ref:`continuous backups <pit-restore>` aren't necessary for 
+  a {+cluster+}, disable this feature to reduce costs.
+
+- :ref:`Lower the frequency of backups <creating-backup-policy>` for less critical 
+  {+clusters+}.
+
+Optimize Data Transfer Patterns
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Whenever possible, opt for same-provider, same-region data transfer to minimize 
+costs. Only use inter-region or internet transfers when necessary. Locating your 
+{+cluster+} in the same region as most of your traffic — likely where you host your 
+application — can greatly reduce data transfer costs.
+
+Optimize Queries
+~~~~~~~~~~~~~~~~
+
+Queries that take a long time to execute can increase resource usage, 
+requiring higher-tier {+clusters+}. :ref:`Optimize these queries <performance-advisor>` 
+to reduce resource consumption and lower costs as a result.
+
+Optimize Storage
+~~~~~~~~~~~~~~~~
+
+Use features like :ref:`online archive <online-archive-overview>` 
+or :manual:`TTL indexes </core/index-ttl/>` to 
+move older data from more expensive hot storage to less expensive cold 
+storage. After you archive data, you can access the data through 
+:ref:`Atlas Data Federation <data-federation-overview>`. 
+
+Use Cost Explorer
+~~~~~~~~~~~~~~~~~
+
+Regularly use the :ref:`Cost Explorer <cost-explorer>` tool to monitor spending 
+patterns at the organization, project, {+cluster+}, and service levels. Set a 
+frequency that works for your needs.
+
+Set Alerts
+~~~~~~~~~~
+
+Configure :ref:`billing alerts <billing-alerts>` for key thresholds, such as 
+when your monthly costs exceed a certain amount.  For example, set an alert when 
+costs exceed $100. This proactive approach helps you avoid surprises.
+
+Review Invoices
+~~~~~~~~~~~~~~~
+
+Each month, review your invoice to assess the highest-cost services using the 
+previous billing optimization suggestions. This is a recommended best practice 
+to identify cost reduction opportunities.
+
+If you see unexpected changes on your invoice, check your cloud
+computing costs, which are often the largest portion of your bill. You
+can review cloud computing costs in the :guilabel:`Summary By Service`
+card of any invoice within the |service| :guilabel:`Billing` section.
+The :guilabel:`Summary By Service` view shows the costs of all
+{+clusters+} by provider, tier, and region. 
+
+Use Support Resources
+~~~~~~~~~~~~~~~~~~~~~
+
+- :ref:`Atlas Basic Support <atlas-support>`: Available for all customers at no 
+  additional cost, providing a foundational level of assistance.
+
+- :ref:`Developer and Premium Support <atlas-support>`: For teams that require 
+  faster response times and end-to-end database support. 
+
+- `Consulting Sessions <https://www.mongodb.com/services/consulting>`__: For 
+  complex workloads, consider consulting sessions to focus on optimization and 
+  cost reduction strategies.


### PR DESCRIPTION
I came up with this so far -- it's mainly the section from the page Jeff worked on where he had all the opimization things in an includes file already. I mentioned auto-scaling as an option, not necessarily on what to use with it, and linked out to the cluster size guide on the hierarchy page.

Also, I know you mentioned to add links to the Backup and Scalability pages since they also cover some cost optimization
things, but they're currently blank and I'm not sure exactly what or where it'll be mentioned yet.

[DOCSP-43352](https://jira.mongodb.org/browse/DOCSP-43352)
Staging