### PR TITLE
DOCSP-45053 added tags to hierarchy create cluster page

### DIFF
--- a/source/includes/examples/cli-example-create-clusters-devtest.rst
+++ b/source/includes/examples/cli-example-create-clusters-devtest.rst
@@ -2,7 +2,7 @@
    :copyable: true
 
    atlas clusters create CustomerPortalDev \
-     --projectId 618d48e05277a606ed2496fe \
+     --projectId 56fd11f25f23b33ef4c2a331 \
      --region EASTERN_US \
      --members 3 \
      --tier M10 \

--- a/source/includes/examples/cli-example-create-clusters-devtest.rst
+++ b/source/includes/examples/cli-example-create-clusters-devtest.rst
@@ -2,13 +2,17 @@
    :copyable: true
 
    atlas clusters create CustomerPortalDev \
-     --projectId 56fd11f25f23b33ef4c2a331 \
+     --projectId 618d48e05277a606ed2496fe \
      --region EASTERN_US \
      --members 3 \
      --tier M10 \
      --provider GCP \
      --mdbVersion 8.0 \
      --diskSizeGB 30 \
+     --tag bu=ConsumerProducts \
+     --tag teamName=TeamA \
+     --tag appName=ProductManagementApp \
+     --tag env=Production \
+     --tag version=8.0 \
+     --tag email=marissa@acme.com \
      --watch
-
-

--- a/source/includes/examples/cli-example-create-clusters-stagingprod.rst
+++ b/source/includes/examples/cli-example-create-clusters-stagingprod.rst
@@ -1,6 +1,6 @@
 .. code-block::
    :copyable: true
 
-   atlas cluster create --projectId 5e2211c17a3e5a48f5497de3 --tag bu=ConsumerProducts teamName=TeamA appName=ProductManagementApp env=Production version=8.0 email=marissa@acme.com --file cluster.json
+   atlas cluster create --projectId 5e2211c17a3e5a48f5497de3 --file cluster.json
 
 

--- a/source/includes/examples/cli-example-create-clusters-stagingprod.rst
+++ b/source/includes/examples/cli-example-create-clusters-stagingprod.rst
@@ -1,6 +1,6 @@
 .. code-block::
    :copyable: true
 
-   atlas cluster create --projectId 5e2211c17a3e5a48f5497de3 --file cluster.json
+   atlas cluster create --projectId 5e2211c17a3e5a48f5497de3 --tag bu=ConsumerProducts teamName=TeamA appName=ProductManagementApp env=Production version=8.0 email=marissa@acme.com --file cluster.json
 
 

--- a/source/includes/examples/cli-json-example-create-clusters.rst
+++ b/source/includes/examples/cli-json-example-create-clusters.rst
@@ -40,12 +40,12 @@
            "zoneName": "Zone 1"
          }
        ],
-       tags = {
+       "tag" : [{
          "bu": "ConsumerProducts",
          "teamName": "TeamA",
          "appName": "ProductManagementApp",
          "env": "Production",
          "version": "8.0",
          "email": "marissa@acme.com"
-       }
+       }]
      }

--- a/source/includes/examples/cli-json-example-create-clusters.rst
+++ b/source/includes/examples/cli-json-example-create-clusters.rst
@@ -42,10 +42,10 @@
        ],
        tags = {
          "bu": "ConsumerProducts",
-         "teamName": "TeamA"
-         "appName": "ProductManagementApp"
-         "env": "Production"
-         "version": "8.0"
+         "teamName": "TeamA",
+         "appName": "ProductManagementApp",
+         "env": "Production",
+         "version": "8.0",
          "email": "marissa@acme.com"
        }
      }

--- a/source/includes/examples/cli-json-example-create-clusters.rst
+++ b/source/includes/examples/cli-json-example-create-clusters.rst
@@ -39,5 +39,13 @@
            ],
            "zoneName": "Zone 1"
          }
-       ]
+       ],
+       tags = {
+         "bu": "ConsumerProducts",
+         "teamName": "TeamA"
+         "appName": "ProductManagementApp"
+         "env": "Production"
+         "version": "8.0"
+         "email": "marissa@acme.com"
+       }
      }

--- a/source/includes/examples/tf-example-main-devtest.rst
+++ b/source/includes/examples/tf-example-main-devtest.rst
@@ -28,6 +28,14 @@
          region_name   = var.atlas_region
        }
      }
+     tags {
+       BU       = "ConsumerProducts"
+       TeamName = "TeamA"
+       AppName  = "ProductManagementApp"
+       Env      = "Production"
+       Version  = "8.0"
+       Email    = "marissa@acme.com"
+     }
    }
    
    # Outputs to Display

--- a/source/includes/examples/tf-example-main-devtest.rst
+++ b/source/includes/examples/tf-example-main-devtest.rst
@@ -29,12 +29,28 @@
        }
      }
      tags {
-       BU       = "ConsumerProducts"
-       TeamName = "TeamA"
-       AppName  = "ProductManagementApp"
-       Env      = "Production"
-       Version  = "8.0"
-       Email    = "marissa@acme.com"
+       key   = "BU"
+       value = "ConsumerProducts"
+     }
+     tags {
+       key   = "TeamName"
+       value = "TeamA"
+     }
+     tags {
+       key   = "AppName"
+       value = "ProductManagementApp"
+     }
+     tags {
+       key   = "Env"
+       value = "Test"
+     }
+     tags {
+       key   = "Version"
+       value = "8.0"
+     }
+     tags {
+       key   = "Email"
+       value = "marissa@acme.com"
      }
    }
    

--- a/source/includes/examples/tf-example-main-stagingprod.rst
+++ b/source/includes/examples/tf-example-main-stagingprod.rst
@@ -29,12 +29,28 @@
        }
      }
      tags {
-       BU       = "ConsumerProducts"
-       TeamName = "TeamA"
-       AppName  = "ProductManagementApp"
-       Env      = "Production"
-       Version  = "8.0"
-       Email    = "marissa@acme.com"
+       key   = "BU"
+       value = "ConsumerProducts"
+     }
+     tags {
+       key   = "TeamName"
+       value = "TeamA"
+     }
+     tags {
+       key   = "AppName"
+       value = "ProductManagementApp"
+     }
+     tags {
+       key   = "Env"
+       value = "Production"
+     }
+     tags {
+       key   = "Version"
+       value = "8.0"
+     }
+     tags {
+       key   = "Email"
+       value = "marissa@acme.com"
      }
    }
    

--- a/source/includes/examples/tf-example-main-stagingprod.rst
+++ b/source/includes/examples/tf-example-main-stagingprod.rst
@@ -28,7 +28,7 @@
          region_name   = var.atlas_region
        }
      }
-     tags = {
+     tags {
        BU       = "ConsumerProducts"
        TeamName = "TeamA"
        AppName  = "ProductManagementApp"

--- a/source/includes/examples/tf-example-main-stagingprod.rst
+++ b/source/includes/examples/tf-example-main-stagingprod.rst
@@ -28,6 +28,14 @@
          region_name   = var.atlas_region
        }
      }
+     tags = {
+       BU       = "ConsumerProducts"
+       TeamName = "TeamA"
+       AppName  = "ProductManagementApp"
+       Env      = "Production"
+       Version  = "8.0"
+       Email    = "marissa@acme.com"
+     }
    }
    
    # Outputs to Display


### PR DESCRIPTION
For Terraform, I used [this](https://registry.terraform.io/providers/mongodb/mongodbatlas/latest/docs/resources/advanced_cluster) page as a reference.

[JIRA](https://jira.mongodb.org/browse/DOCSP-45053)
[Staging](https://deploy-preview-32--docs-atlas-architecture.netlify.app/hierarchy/#create-one-cluster-per-project)