### PR TITLE
Removes analytics nodes from TF examples as they are not needed

### DIFF
--- a/source/includes/examples/tf-example-complete-staging-prod.tf
+++ b/source/includes/examples/tf-example-complete-staging-prod.tf
@@ -16,10 +16,6 @@ resource "mongodbatlas_advanced_cluster" "atlas-cluster" {
         instance_size = var.cluster_instance_size_name
         node_count    = 3
       }
-      analytics_specs {
-        instance_size = var.cluster_instance_size_name
-        node_count    = 1
-      }
       priority      = 7
       provider_name = var.cloud_provider
       region_name   = var.atlas_region

--- a/source/includes/examples/tf-example-main-devtest.rst
+++ b/source/includes/examples/tf-example-main-devtest.rst
@@ -19,10 +19,6 @@
            instance_size = var.cluster_instance_size_name
            node_count    = 3
          }
-         analytics_specs {
-           instance_size = var.cluster_instance_size_name
-           node_count    = 1
-         }
          priority      = 7
          provider_name = var.cloud_provider
          region_name   = var.atlas_region

--- a/source/includes/examples/tf-example-main-stagingprod.rst
+++ b/source/includes/examples/tf-example-main-stagingprod.rst
@@ -32,10 +32,6 @@
            instance_size = var.cluster_instance_size_name
            node_count    = 3
          }
-         analytics_specs {
-           instance_size = var.cluster_instance_size_name
-           node_count    = 1
-         }
          priority      = 7
          provider_name = var.cloud_provider
          region_name   = var.atlas_region


### PR DESCRIPTION
Analytics nodes are optional and not part of our recommendations, so these are not needed.

I tested successfully with `terraform plan`

Staging (TF tab): https://deploy-preview-112--docs-atlas-architecture.netlify.app/hierarchy/#create-one-cluster-per-project
![Screenshot 2025-02-02 at 8 13 06 AM](https://github.com/user-attachments/assets/2893ea65-faf7-4016-b91b-032c9c9bc49a)
