### PR TITLE
(DOCSP-47172) Fix diagrams not expanding on click

### DIFF
--- a/source/landing-zone.txt
+++ b/source/landing-zone.txt
@@ -213,6 +213,7 @@ landing zone. You can adjust it as needed to customize it for your organization.
 
 .. figure:: /includes/images/LandingZone.svg
    :alt: "A diagram showing an example {+service+} landing zone."
+   :figwidth: 1000px
    :align: center
    :lightbox:
 


### PR DESCRIPTION
This seems to be a platform limitation in that the size of your monitor determines the max height of the expanded image. For small monitors, readability may continue to be an issue, but this PR fixes the most detailed diagram's issues by making it larger.

Staging: https://deploy-preview-115--docs-atlas-architecture.netlify.app/landing-zone/#example-landing-zone-diagram