### PR TITLE
Recommends Service Accounts (in preview, no automation examples)

### DIFF
--- a/source/auth.txt
+++ b/source/auth.txt
@@ -240,12 +240,36 @@ To learn more, see the blog :website:`Manage
 MongoDB Atlas Database Secrets in HashiCorp Vault 
 </blog/post/manage-atlas-database-secrets-hashicorp-vault>`.
 
+.. _arch-center-admin-api-recs:
 
 Recommendations for {+atlas-admin-api+} 
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-|service| provides |api| key-based authentication to securely manage
-programmatic access. It uses |http| Digest authentication to protect requests.
+|service| provides two ways to authenticate to the {+atlas-admin-api+}:
+
+- :atlas:`Service accounts </api/service-accounts-overview/>`
+  (currently available as a `Preview feature 
+  <https://www.mongodb.com/resources/products/early-access>`__)
+- |api| keys
+
+Service Accounts
+````````````````
+
+Service accounts use industry-standard OAuth2.0 to securely authenticate
+with {+service+} through the {+atlas-admin-api+}. We recommend that you use service accounts instead of |api| keys when possible because they provide added security through use short-lived
+access tokens and required credential rotations.
+
+Service accounts are
+available as a Preview feature, and you can manage programmatic access for service accounts only by using the {+atlas-ui+} or the {+atlas-admin-api+}. You can't manage
+programmatic access for service accounts through the {+atlas-cli+} or Terraform.
+
+To learn more, see :atlas:`Service Accounts Overview </api/service-accounts-overview/>`.
+
+API Keys
+````````
+
+If you don't use Service Accounts, you can use |api| key-based authentication to securely manage
+programmatic access. |api| key-based authentication uses |http| Digest authentication to protect requests.
 The |api| public key functions as the username, and the corresponding
 private key serves as the password. 
 You should store these keys in a third party secrets management system, 
@@ -299,7 +323,8 @@ only be allowed in lower environments during development and testing.
 Recommendations for {+atlas-ui+} and {+atlas-admin-api+} (Control Plane)
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-You can assign users and API keys to predefined roles, specifying the
+You can assign users, service accounts, and API keys to predefined
+roles, specifying the
 actions they can perform within |service| organizations, projects, or
 both. Use Identity Federation to manage access by linking your identity
 provider groups to |service| roles through group-role mappings.  

--- a/source/auth.txt
+++ b/source/auth.txt
@@ -268,7 +268,7 @@ To learn more, see :atlas:`Service Accounts Overview </api/service-accounts-over
 API Keys
 ````````
 
-If you don't use Service Accounts, you can use |api| key-based authentication to securely manage
+If you don't use service accounts, you can use |api| key-based authentication to securely manage
 programmatic access. |api| key-based authentication uses |http| Digest authentication to protect requests.
 The |api| public key functions as the username, and the corresponding
 private key serves as the password. 

--- a/source/auth.txt
+++ b/source/auth.txt
@@ -248,8 +248,8 @@ Recommendations for {+atlas-admin-api+}
 |service| provides two ways to authenticate to the {+atlas-admin-api+}:
 
 - :atlas:`Service accounts </api/service-accounts-overview/>`
-  (currently available as a `Preview feature 
-  <https://www.mongodb.com/resources/products/early-access>`__)
+  (currently available as a :website:`Preview feature 
+  </resources/products/early-access>`\)
 - |api| keys
 
 Service Accounts


### PR DESCRIPTION
Staging:

- [Auth page](https://deploy-preview-117--docs-atlas-architecture.netlify.app/auth/#recommendations-for-atlas-administration-api)
- [Automation page](https://deploy-preview-117--docs-atlas-architecture.netlify.app/automation/#atlas-administration-api)

I reviewed the content on all pages to ensure these are the only spots we need to change for now. There's a ticket for more changes in a future iteration when they GA: https://jira.mongodb.org/browse/DOCSP-46935, also another ticket to remove the "Preview" note when they GA.

This does NOT change any example sections or recs there because they can't yet manage service accounts with CLI or TF. Simply states that SAs are available and preferred when possible, and links to the docs on them