### PR TITLE
DOCSP-47289 -- Removed mentions of service accounts as a preview feature

### DIFF
--- a/source/auth.txt
+++ b/source/auth.txt
@@ -249,20 +249,19 @@ MongoDB Atlas Database Secrets in HashiCorp Vault
 |service| provides two ways to authenticate to the {+atlas-admin-api+}:
 
 - :atlas:`Service accounts </api/service-accounts-overview/>`
-  (currently available as a :website:`Preview feature 
-  </resources/products/early-access>`\)
 - |api| keys
 
 Service Accounts
 ````````````````
 
-Service accounts use industry-standard OAuth2.0 to securely authenticate
-with {+service+} through the {+atlas-admin-api+}. We recommend that you use service accounts instead of |api| keys when possible because they provide added security through use short-lived
+Service accounts use industry-standard OAuth2.0 to securely authenticate with {+service+}
+through the {+atlas-admin-api+}. We recommend that you use service accounts instead of
+|api| keys when possible because they provide added security through short-lived
 access tokens and required credential rotations.
 
-Service accounts are
-available as a Preview feature, and you can manage programmatic access for service accounts only by using the {+atlas-ui+} or the {+atlas-admin-api+}. You can't manage
-programmatic access for service accounts through the {+atlas-cli+} or Terraform.
+You can manage programmatic access for service accounts only through the {+atlas-ui+} or
+the {+atlas-admin-api+}. You can't manage programmatic access for service accounts through
+the {+atlas-cli+} or Terraform.
 
 To learn more, see :atlas:`Service Accounts Overview </api/service-accounts-overview/>`.
 


### PR DESCRIPTION
[DOCSP-47289](https://jira.mongodb.org/browse/DOCSP-47289)
[Staging](https://deploy-preview-149--docs-atlas-architecture.netlify.app/auth/#atlas-administration-api-authentication)  