### PR TITLE
(DOCSP-48693) Fixes 404s in the Arch Center docs

### DIFF
--- a/source/hierarchy.txt
+++ b/source/hierarchy.txt
@@ -43,14 +43,14 @@ security settings and governance for your {+service+} enterprise estate:
    * - (Optional) Paying Organization
      - One organization can be a paying organization for other
        organization(s). A paying organization lets you set up 
-       :atlas:`cross-organization billing <billing/#std-label-cross-org-billing>` 
+       :atlas:`cross-organization billing </billing/#std-label-cross-org-billing>` 
        to share a billing subscription across multiple organizations. 
        To learn more about setting up your paying organization when 
-       you establish the |service| subscription, see :atlas:`Manage Billing <billing>`.  
+       you establish the |service| subscription, see :atlas:`Manage Billing </billing>`.  
        In order to enable cross-organization billing, the user performing 
        the action must have an Org Owner or Billing Admin role of both 
        organizations that they wish to link. To learn more, see 
-       :atlas:`User Roles <user-roles>`.
+       :atlas:`User Roles </reference/user-roles>`.
 
        A paying organization is common for large enterprises with many
        {+BU+}\s or departments that operate independently but where the
@@ -60,7 +60,7 @@ security settings and governance for your {+service+} enterprise estate:
      - An organization can contain many projects under it and provides
        a container to apply shared integration and security settings. If 
        you manage multiple {+service+} organizations, the 
-       :atlas:`Atlas Federation Management Console <atlas-federated-authentication>` 
+       :ref:`Atlas Federation Management Console <atlas-federated-authentication>` 
        allows users with an Org Owner role to manage |idps| for |sso|, 
        then link them to multiple organizations. 
        An organization often maps to a {+BU+} or department within a


### PR DESCRIPTION
[DOCSP](https://jira.mongodb.org/browse/DOCSP-48693)
[Staging](https://deploy-preview-150--docs-atlas-architecture.netlify.app/hierarchy/#features-for-atlas-orgs--projects--and-clusters)

I verified that this fixes the 404ing links