### PR TITLE
(DOCSP-48700) Adds cards and updates the banner

### DIFF
--- a/snooty.toml
+++ b/snooty.toml
@@ -383,5 +383,7 @@ workload = "Workload Identity Federation"
 targets = ["index.txt", "high-availability.txt", "resiliency.txt"]
 variant = "info"
 value = """\
-    The {+atlas-arch-center+} is in early release and includes recommendations for a single-cloud, single-region architecture. MongoDB plans to add multi-region recommendations, recommendations for compliance with external standards, and a plug-and-play Terraform code repository in future releases.
+    The {+atlas-arch-center+} is in early release. MongoDB plans to add
+    recommendations for compliance with external standards
+    and a plug-and-play Terraform code repository in future releases.
     """

--- a/source/getting-started.txt
+++ b/source/getting-started.txt
@@ -27,7 +27,7 @@ Use the following resources to get started with |service| and the
       :icon: general_cloud_global
       :icon-alt:  icon
 
-      Choose your deployment paradigm, such as a multi-region or global deployment.
+      Choose your deployment paradigm, such as a multi-region, global, or hybrid deployment.
 
    .. card::
       :headline: Orgs, Projects, and Clusters

--- a/source/getting-started.txt
+++ b/source/getting-started.txt
@@ -24,7 +24,7 @@ Use the following resources to get started with |service| and the
    .. card::
       :headline: Deployment Paradigms
       :url: https://mongodb.com/docs/atlas/architecture/deployment-paradigms/
-      :icon: general_cloud_global
+      :icon: cloud_global
       :icon-alt:  icon
 
       Choose your deployment paradigm, such as a multi-region, global, or hybrid deployment.
@@ -40,7 +40,7 @@ Use the following resources to get started with |service| and the
    .. card::
       :headline: Migration
       :url: https://mongodb.com/docs/atlas/architecture/migration/
-      :icon: technical_mdb_live_migration
+      :icon: mdb_live_migration
       :icon-alt:  icon 
 
       Select a method for migrating to |service|.

--- a/source/getting-started.txt
+++ b/source/getting-started.txt
@@ -22,6 +22,14 @@ Use the following resources to get started with |service| and the
       Learn how to define a landing zone for your organization.
 
    .. card::
+      :headline: Deployment Paradigms
+      :url: https://mongodb.com/docs/atlas/architecture/deployment-paradigms/
+      :icon: general_cloud_global
+      :icon-alt:  icon
+
+      Choose your deployment paradigm, such as a multi-region or global deployment.
+
+   .. card::
       :headline: Orgs, Projects, and Clusters
       :url: https://mongodb.com/docs/atlas/architecture/hierarchy/
       :icon: general_features_global_clusters
@@ -29,9 +37,27 @@ Use the following resources to get started with |service| and the
 
       Set up the foundational {+service+} components.
 
+   .. card::
+      :headline: Migration
+      :url: https://mongodb.com/docs/atlas/architecture/migration/
+      :icon: technical_mdb_live_migration
+      :icon-alt:  icon 
+
+      Select a method for migrating to |service|.
+
+   .. card::
+      :headline: Operational Readiness Checklist
+      :url: https://mongodb.com/docs/atlas/architecture/operational-readiness-checklist/
+      :icon: general_action_audit
+      :icon-alt:  icon
+
+      Use a checklist to help you prepare for a deployment.
+
 .. toctree::
    :titlesonly:
 
    Landing Zone Design </landing-zone>
    Deployment Paradigms </deployment-paradigms>
    Orgs, Projects, and Clusters </hierarchy>
+   Migration </migration>
+   Operational Readiness Checklist </operational-readiness-checklist>

--- a/source/performance.txt
+++ b/source/performance.txt
@@ -27,6 +27,14 @@ performance in {+service+}:
       Use auto-scaling to dynamically allocate resources based on growing workload
       demands. For horizontal and vertical scaling, use {+service+} deployment templates.
 
+   .. card::
+      :headline: Latency Reduction
+      :url: https://mongodb.com/docs/atlas/architecture/latency-reduction/
+      :icon: general_features_real_time
+      :icon-alt: real time icon
+
+      Review best practices for reducing latency.
+
 .. toctree::
    :titlesonly:
 

--- a/source/performance.txt
+++ b/source/performance.txt
@@ -30,7 +30,7 @@ performance in {+service+}:
    .. card::
       :headline: Latency Reduction
       :url: https://mongodb.com/docs/atlas/architecture/latency-reduction/
-      :icon: general_features_real_time
+      :icon: general_features_realtime
       :icon-alt: real time icon
 
       Review best practices for reducing latency.


### PR DESCRIPTION
This PR updates a banner and adds cards to two pages: Getting Started and Performance. 
[DOCSP-48700](https://jira.mongodb.org/browse/DOCSP-48700)

Staging:

[Getting Started](https://deploy-preview-158--docs-atlas-architecture.netlify.app/getting-started/) now has three new cards
[Performance](https://deploy-preview-158--docs-atlas-architecture.netlify.app/performance/) has one new card


Banner is updated.

Notes:
- The icons for the new cards don't display yet as I need to see how to refer to them properly (I am checking on this with the design team)
- Some links won't work as the new pages aren't added to the TOC yet.

For example I have no information about Latency Reduction page -- I don't know who will add it. 

Thank you for your review, @corryroot!




