### PR TITLE
(DOCSP-48740) [Atlas Architecture]Link to High Availability from the Cost Saving Config page

### DIFF
--- a/source/includes/billing-optimizations.rst
+++ b/source/includes/billing-optimizations.rst
@@ -116,3 +116,10 @@ can review cloud computing costs in the :guilabel:`Summary By Service`
 card of any invoice within the |service| :guilabel:`Billing` section.
 The :guilabel:`Summary By Service` view shows the costs of all
 {+clusters+} by provider, tier, and region.
+
+Choose the Right Deployment Paradigm and Topology
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+The deployment topology you choose can change your |service| costs.
+
+To learn more about cost savings for {+cluster+} configurations, see :ref:`arch-center-high-availability`. 

--- a/source/includes/billing-optimizations.rst
+++ b/source/includes/billing-optimizations.rst
@@ -1,7 +1,7 @@
 Consider these strategies for optimizing your |service| costs.
 
-Underutilized {+Clusters+}
-~~~~~~~~~~~~~~~~~~~~~~~~~~
+Scale Down Underutilized {+Clusters+}
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 - Enable :ref:`auto-scaling <cluster-autoscaling>` on your {+cluster+}
   tier to match your usage and prevent over-provisioning.
@@ -47,9 +47,8 @@ Underutilized {+Clusters+}
       <https://registry.terraform.io/providers/mongodb/mongodbatlas/latest/docs/resources/cluster#termination_protection_enabled-2>`__
       by setting the ``termination_protection_enabled`` field to ``false``.
 
-
-High Backup Frequency
-~~~~~~~~~~~~~~~~~~~~~
+Optimize Backup Frequency
+~~~~~~~~~~~~~~~~~~~~~~~~~
 
 - :ref:`Continuous backups <pit-restore>` are expensive, but they give
   you the most safety to recover data from any point in time within the
@@ -120,6 +119,6 @@ The :guilabel:`Summary By Service` view shows the costs of all
 Choose the Right Deployment Paradigm and Topology
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-The deployment topology you choose can change your |service| costs.
+The deployment paradigm and topology you choose can change your |service| costs.
 
-To learn more about cost savings for {+cluster+} configurations, see :ref:`arch-center-high-availability`. 
+To learn more about cost savings for different topologies, see :ref:`arch-center-high-availability`. 


### PR DESCRIPTION
In the [Cost-Saving config](https://www.mongodb.com/docs/atlas/architecture/cost-saving-config/) page, add a link to the High Availability page because we will be adding a table to the HA page this iteration that shows the cost savings by tier based on the topology you choose. Something like:

> **Choose the Right Deployment Paradigm and Topology**

> The deployment paradigm and topology you choose can change your Atlas costs. To learn more about cost savings for different topologies, see [Guidance for High Availability](https://www.mongodb.com/docs/atlas/architecture/current/backups/).

## JIRA
[DOCSP-48740](https://jira.mongodb.org/browse/DOCSP-48740)
## STAGING
https://deploy-preview-159--docs-atlas-architecture.netlify.app/cost-saving-config/