### PR TITLE
DOCSP-49175-IS-section

### DIFF
--- a/snooty.toml
+++ b/snooty.toml
@@ -32,6 +32,7 @@ toc_landing_pages = [
     "/reliability",
     "/performance",
     "/cost-optimization",
+    "/industry-solutions"
 ]
 
 [constants]

--- a/source/index.txt
+++ b/source/index.txt
@@ -125,4 +125,5 @@ Find features and best practices for each {+service+} {+waf+} pillar.
    Reliability </reliability>
    Performance </performance>
    Cost Optimization </cost-optimization>
+   Industry Solutions </industry-solutions>
    Release Notes </release-notes>

--- a/source/industry-solutions.txt
+++ b/source/industry-solutions.txt
@@ -1,0 +1,11 @@
+.. _arch-center-industry-solutions:
+
+==================
+Industry Solutions
+==================
+
+.. contents:: On this page
+   :local:
+   :backlinks: none
+   :depth: 2
+   :class: onecol

--- a/source/industry-solutions.txt
+++ b/source/industry-solutions.txt
@@ -3,9 +3,3 @@
 ==================
 Industry Solutions
 ==================
-
-.. contents:: On this page
-   :local:
-   :backlinks: none
-   :depth: 2
-   :class: onecol


### PR DESCRIPTION
## Description

Add a top-level heading where we can put our Industry Solutions pages. Currently just a blank page. We can add links to our sub-pages as we create them.

## JIRA

https://jira.mongodb.org/browse/DOCSP-49175

## Staging

https://deploy-preview-165--docs-atlas-architecture.netlify.app/industry-solutions/