### PR TITLE
(DOCSP-49287) [Atlas Architecture] Backups first draft changes

### DIFF
--- a/source/backups.txt
+++ b/source/backups.txt
@@ -112,18 +112,19 @@ Recommendations for {+service+} Backups
    :sub_heading: Recommendations that apply only to deployments across multiple regions or multiple cloud providers
    :expanded: true
 
-   To ensure automatic failover in the event of a primary region failure, we recommend that you deploy your database 
-   across three or more regions. If you choose a three-region topology, such as our recommended five-node, three-region topology, then 
-   maintaining backups is not necessary for fault tolerance or disaster recovery. 
-   To learn more about which multi-region deployment models ensure high availability of data, see :ref:`arch-center-deployment-topologies`. 
-
-   If you choose a two-region topology, there is a possibility for data loss if the majority region is lost and your 
+   If you choose a multi-region deployment model with three or more regions, such as our recommended five-node, three-region topology, 
+   then maintaining backups is not necessary for fault tolerance, disaster recovery, or high availability.
+   Deploying to three or more regions guarantees automatic failover in the event of a primary region failure,
+   making backups unnecessary to prevent data loss in the event of a regional disruption.
+   Therefore, restoring backups to a three-region deployment is only necessary in cases where you want to recover back to particular timestamps, such as to revert to older versions
+   of data after a large data corruption event or accidental deletion of data. 
+   
+   However, if you choose a two-region topology, there is a possibility for data loss if the majority region is lost and your 
    MongoDB process didn't replicate write operations to the node that becomes primary after the reconfiguration.
    We don't recommend a two-region topology for customers with three supported regions. 
 
-   If you select a multi-region deployment mode, restoring backups may be important for certain use cases, such as to revert to older versions
-   of data after a large data corruption event or accidental deletion of data. 
-   
+   To learn more about which multi-region deployment models ensure high availability of data, see :ref:`arch-center-deployment-topologies`. 
+
 All Deployment Paradigm Recommendations
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 

--- a/source/backups.txt
+++ b/source/backups.txt
@@ -131,8 +131,9 @@ maximum acceptable amount of data loss during an incident, while RTO
 defines how quickly your application must recover. Since data varies in
 importance, you must evaluate RPO and RTO for each application
 individually. For example, any mission-critical data will likely have 
-different requirements than clickstream analytics. Your requirements
-for RTO, RPO, and the backup retention period will influence the cost
+different requirements than clickstream analytics.
+
+Your requirements for RTO, RPO, and the backup retention period will influence the cost
 and performance considerations of maintaining backups. In development
 and test environments, we recommend that you disable backup to save
 costs. In staging and production environments, ensure that backup is
@@ -151,6 +152,13 @@ window of seven days. Adjust this time range with a longer setting based
 on the criticality of the workload. This allows you to replay the oplog
 to restore a {+cluster+} from a particular point in time and satisfy
 your RTO.
+
+If you select a multi-region deployment model, such as our recommended 5-node, 3-region topology,
+then restoring backups is not necessary for fault tolerance, disaster recovery, or high availability.
+However, restoring backups may be important for certain use cases, such as to revert to older versions
+of data after a large data corruption event or accidental deletion of data.
+To learn more about how multi-region deployment models ensure high availability of data, see 
+:ref:`arch-center-deployment-topologies`. 
 
 .. seealso:: 
 
@@ -281,7 +289,7 @@ backup is enabled for the {+cluster+}.
    .. tab:: CLI
       :tabid: cli
 
-      Run the following command take a backup snapshot for the {+cluster+}
+      Run the following command to take a backup snapshot for the {+cluster+}
       named myDemo and retain the snapshot for 7 days:
 
       .. include:: /includes/examples/cli-example-backup-take-snapshot.rst

--- a/source/backups.txt
+++ b/source/backups.txt
@@ -112,18 +112,17 @@ Recommendations for {+service+} Backups
    :sub_heading: Recommendations that apply only to deployments across multiple regions or multiple cloud providers
    :expanded: true
 
-   If you choose a multi-region deployment model with three or more regions, such as our recommended five-node, three-region topology, 
-   then maintaining backups is not necessary for fault tolerance, disaster recovery, or high availability.
-   Deploying to three or more regions guarantees automatic failover in the event of a primary region failure,
-   making backups unnecessary to prevent data loss in the event of a regional disruption.
-   Therefore, restoring backups to a three-region deployment is only necessary in cases where you want to recover back to particular timestamps, such as to revert to older versions
-   of data after a large data corruption event or accidental deletion of data. 
-   
-   However, if you choose a two-region topology, there is a possibility for data loss if the majority region is lost and your 
-   MongoDB process didn't replicate write operations to the node that becomes primary after the reconfiguration.
-   We don't recommend a two-region topology for customers with three supported regions. 
+   Deploying your cluster to three or more regions guarantees automatic failover in the event of a primary region failure,
+   making backups unnecessary to prevent data loss in the event of a regional disruption. However, we recommend that all 
+   multi-region and multi-cloud deployments enable local |service| cloud backups or continuous cloud backups
+   to support recovery back to previous versions of data in the event of a large data corruption event or accidental deletion of 
+   data that has overwritten the current data in all active regions.
 
-   To learn more about which multi-region deployment models ensure high availability of data, see :ref:`arch-center-deployment-topologies`. 
+   If you select a multi-region deployment, the built-in replication meets compliance requirements of storing
+   backups in different geographical locations to ensure disaster recovery in case of regional outages. To learn more,
+   see :atlas:`Snapshot Distribution </backup/cloud-backup/snapshot-distribution/>`.
+
+   To learn more about which multi-region deployment models ensure high availability of data with and without backups, see :ref:`arch-center-deployment-topologies`. 
 
 All Deployment Paradigm Recommendations
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/source/backups.txt
+++ b/source/backups.txt
@@ -112,8 +112,18 @@ Recommendations for {+service+} Backups
    :sub_heading: Recommendations that apply only to deployments across multiple regions or multiple cloud providers
    :expanded: true
 
-   Recommendations here
+   To ensure automatic failover in the event of a primary region failure, we recommend that you deploy your database 
+   across three or more regions. If you choose a three-region topology, such as our recommended five-node, three-region topology, then 
+   maintaining backups is not necessary for fault tolerance or disaster recovery. 
+   To learn more about which multi-region deployment models ensure high availability of data, see :ref:`arch-center-deployment-topologies`. 
 
+   If you choose a two-region topology, there is a possibility for data loss if the majority region is lost and your 
+   MongoDB process didn't replicate write operations to the node that becomes primary after the reconfiguration.
+   We don't recommend a two-region topology for customers with three supported regions. 
+
+   If you select a multi-region deployment mode, restoring backups may be important for certain use cases, such as to revert to older versions
+   of data after a large data corruption event or accidental deletion of data. 
+   
 All Deployment Paradigm Recommendations
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
@@ -152,13 +162,6 @@ window of seven days. Adjust this time range with a longer setting based
 on the criticality of the workload. This allows you to replay the oplog
 to restore a {+cluster+} from a particular point in time and satisfy
 your RTO.
-
-If you select a multi-region deployment model, such as our recommended 5-node, 3-region topology,
-then restoring backups is not necessary for fault tolerance, disaster recovery, or high availability.
-However, restoring backups may be important for certain use cases, such as to revert to older versions
-of data after a large data corruption event or accidental deletion of data.
-To learn more about how multi-region deployment models ensure high availability of data, see 
-:ref:`arch-center-deployment-topologies`. 
 
 .. seealso:: 
 

--- a/source/backups.txt
+++ b/source/backups.txt
@@ -112,17 +112,16 @@ Recommendations for {+service+} Backups
    :sub_heading: Recommendations that apply only to deployments across multiple regions or multiple cloud providers
    :expanded: true
 
-   Deploying your cluster to three or more regions guarantees automatic failover in the event of a primary region failure,
-   making backups unnecessary to prevent data loss in the event of a regional disruption. However, we recommend that all 
-   multi-region and multi-cloud deployments enable local |service| cloud backups or continuous cloud backups
-   to support recovery back to previous versions of data in the event of a large data corruption event or accidental deletion of 
-   data that has overwritten the current data in all active regions.
-
-   If you select a multi-region deployment, the built-in replication meets compliance requirements of storing
-   backups in different geographical locations to ensure disaster recovery in case of regional outages. To learn more,
-   see :atlas:`Snapshot Distribution </backup/cloud-backup/snapshot-distribution/>`.
-
-   To learn more about which multi-region deployment models ensure high availability of data with and without backups, see :ref:`arch-center-deployment-topologies`. 
+   If you choose a multi-region deployment model, we recommend that you deploy to three or more regions to 
+   support automatic failover in the event of a primary region failure. The built-in replication of a multi-region 
+   cluster ensures high availability and fault tolerance without the use of backups. To learn more about which multi-region
+   deployment models ensure high availability of data, see :ref:`arch-center-deployment-topologies`. 
+ 
+   We also recommend that all multi-region and multi-cloud deployments enable local |service| cloud backups or continuous cloud backups
+   for multiple regions to support recovery back to previous versions of data in case of events such as accidental deletions of data or 
+   large data corruption events that have affected data across all regions. 
+   This backup configuration meets the same compliance requirements as enabling 
+   :ref:`multi-region snapshot distribution </backup/cloud-backup/snapshot-distribution/>` for a single-region deployment.
 
 All Deployment Paradigm Recommendations
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/source/backups.txt
+++ b/source/backups.txt
@@ -112,15 +112,14 @@ Recommendations for {+service+} Backups
    :sub_heading: Recommendations that apply only to deployments across multiple regions or multiple cloud providers
    :expanded: true
 
-   If you choose a multi-region deployment model, we recommend that you deploy to three or more regions to 
+   If you select a multi-region deployment model, we recommend that you deploy to three or more regions to 
    support automatic failover in the event of a primary region failure. The built-in replication of a multi-region 
    cluster ensures high availability and fault tolerance without the use of backups. To learn more about which multi-region
    deployment models ensure high availability of data, see :ref:`arch-center-deployment-topologies`. 
  
-   We also recommend that all multi-region and multi-cloud deployments enable local |service| cloud backups or continuous cloud backups
-   for multiple regions to support recovery back to previous versions of data in case of events such as accidental deletions of data or 
-   large data corruption events that have affected data across all regions. 
-   This backup configuration meets the same compliance requirements as enabling 
+   We also recommend that multi-region and multi-cloud deployments enable local |service| cloud backups or continuous cloud backups
+   for multiple regions to support recovery to previous versions of data in case of large data loss or corruption events such as
+   accidental deletions of data. This backup configuration meets the same compliance requirements as enabling 
    :ref:`multi-region snapshot distribution </backup/cloud-backup/snapshot-distribution/>` for a single-region deployment.
 
 All Deployment Paradigm Recommendations

--- a/source/backups.txt
+++ b/source/backups.txt
@@ -100,28 +100,6 @@ monthly, each with its own retention period.
 Recommendations for {+service+} Backups
 ---------------------------------------
 
-.. collapsible::
-   :heading: Single-Region Deployment Recommendations
-   :sub_heading: Recommendations that apply only to deployments in a single region
-   :expanded: true
-
-   Recommendations here
-
-.. collapsible::
-   :heading: Multi-Region and Multi-Cloud Deployment Recommendations
-   :sub_heading: Recommendations that apply only to deployments across multiple regions or multiple cloud providers
-   :expanded: true
-
-   If you select a multi-region deployment model, we recommend that you deploy to three or more regions to 
-   support automatic failover in the event of a primary region failure. The built-in replication of a multi-region 
-   cluster ensures high availability and fault tolerance without the use of backups. To learn more about which multi-region
-   deployment models ensure high availability of data, see :ref:`arch-center-deployment-topologies`. 
- 
-   We also recommend that multi-region and multi-cloud deployments enable local |service| cloud backups or continuous cloud backups
-   for multiple regions to support recovery to previous versions of data in case of large data loss or corruption events such as
-   accidental deletions of data. This backup configuration meets the same compliance requirements as enabling 
-   :atlas:`multi-region snapshot distribution </backup/cloud-backup/snapshot-distribution/>` for a single-region deployment.
-
 All Deployment Paradigm Recommendations
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
@@ -272,7 +250,29 @@ By :ref:`selecting regions <atlas-backup-distribution>` strategically
 for backup, you can avoid cross-region data transfer fees and choose the
 right {+cluster+} disk size based on workload to prevent overspending.
 By implementing these strategies, you can effectively manage costs while
-maintaining secure and reliable backups.   
+maintaining secure and reliable backups.
+
+.. collapsible::
+   :heading: Single-Region Deployment Recommendations
+   :sub_heading: Recommendations that apply only to deployments in a single region
+   :expanded: true
+
+   Recommendations here
+
+.. collapsible::
+   :heading: Multi-Region and Multi-Cloud Deployment Recommendations
+   :sub_heading: Recommendations that apply only to deployments across multiple regions or multiple cloud providers
+   :expanded: true
+
+   If you select a multi-region deployment model, we recommend that you deploy to three or more regions to 
+   support automatic failover in the event of a primary region failure. The built-in replication of a multi-region 
+   cluster ensures high availability and fault tolerance without the use of backups. To learn more about which multi-region
+   deployment models ensure high availability of data, see :ref:`arch-center-deployment-topologies`. 
+ 
+   We also recommend that multi-region and multi-cloud deployments enable local |service| cloud backups or continuous cloud backups
+   for multiple regions to support recovery to previous versions of data in case of large data loss or corruption events such as
+   accidental deletions of data. This backup configuration meets the same compliance requirements as enabling 
+   :atlas:`multi-region snapshot distribution </backup/cloud-backup/snapshot-distribution/>` for a single-region deployment.
 
 Automation Examples: {+service+} Backups
 ----------------------------------------

--- a/source/backups.txt
+++ b/source/backups.txt
@@ -120,7 +120,7 @@ Recommendations for {+service+} Backups
    We also recommend that multi-region and multi-cloud deployments enable local |service| cloud backups or continuous cloud backups
    for multiple regions to support recovery to previous versions of data in case of large data loss or corruption events such as
    accidental deletions of data. This backup configuration meets the same compliance requirements as enabling 
-   :ref:`multi-region snapshot distribution </backup/cloud-backup/snapshot-distribution/>` for a single-region deployment.
+   :atlas:`multi-region snapshot distribution </backup/cloud-backup/snapshot-distribution/>` for a single-region deployment.
 
 All Deployment Paradigm Recommendations
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/source/backups.txt
+++ b/source/backups.txt
@@ -100,6 +100,28 @@ monthly, each with its own retention period.
 Recommendations for {+service+} Backups
 ---------------------------------------
 
+.. collapsible::
+   :heading: Single-Region Deployment Recommendations
+   :sub_heading: Recommendations that apply only to deployments in a single region
+   :expanded: true
+
+   Recommendations here
+
+.. collapsible::
+   :heading: Multi-Region and Multi-Cloud Deployment Recommendations
+   :sub_heading: Recommendations that apply only to deployments across multiple regions or multiple cloud providers
+   :expanded: true
+
+   If you select a multi-region deployment model, we recommend that you deploy to three or more regions to 
+   support automatic failover in the event of a primary region failure. The built-in replication of a multi-region 
+   cluster ensures high availability and fault tolerance without the use of backups. To learn more about which multi-region
+   deployment models ensure high availability of data, see :ref:`arch-center-deployment-topologies`. 
+ 
+   We also recommend that multi-region and multi-cloud deployments enable local |service| cloud backups or continuous cloud backups
+   for multiple regions to support recovery to previous versions of data in case of large data loss or corruption events such as
+   accidental deletions of data. This backup configuration meets the same compliance requirements as enabling 
+   :atlas:`multi-region snapshot distribution </backup/cloud-backup/snapshot-distribution/>` for a single-region deployment.
+
 All Deployment Paradigm Recommendations
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
@@ -251,28 +273,6 @@ for backup, you can avoid cross-region data transfer fees and choose the
 right {+cluster+} disk size based on workload to prevent overspending.
 By implementing these strategies, you can effectively manage costs while
 maintaining secure and reliable backups.
-
-.. collapsible::
-   :heading: Single-Region Deployment Recommendations
-   :sub_heading: Recommendations that apply only to deployments in a single region
-   :expanded: true
-
-   Recommendations here
-
-.. collapsible::
-   :heading: Multi-Region and Multi-Cloud Deployment Recommendations
-   :sub_heading: Recommendations that apply only to deployments across multiple regions or multiple cloud providers
-   :expanded: true
-
-   If you select a multi-region deployment model, we recommend that you deploy to three or more regions to 
-   support automatic failover in the event of a primary region failure. The built-in replication of a multi-region 
-   cluster ensures high availability and fault tolerance without the use of backups. To learn more about which multi-region
-   deployment models ensure high availability of data, see :ref:`arch-center-deployment-topologies`. 
- 
-   We also recommend that multi-region and multi-cloud deployments enable local |service| cloud backups or continuous cloud backups
-   for multiple regions to support recovery to previous versions of data in case of large data loss or corruption events such as
-   accidental deletions of data. This backup configuration meets the same compliance requirements as enabling 
-   :atlas:`multi-region snapshot distribution </backup/cloud-backup/snapshot-distribution/>` for a single-region deployment.
 
 Automation Examples: {+service+} Backups
 ----------------------------------------


### PR DESCRIPTION
Update the [backups](https://www.mongodb.com/docs/atlas/architecture/current/backups/) page to address backup considerations in multi-region architectures, clarifying that they might be less critical for immediate recovery due to the built-in HA, but still important for other reasons (e.g., compliance, longer-term retention). The [Multi-Region Architecture Strawman](https://docs.google.com/document/d/1wn2H4QLR3WXmR8mhvXIp52IZ1uho2_VJ4ejcL4MOiA8/edit?tab=t.0#heading=h.86a6hegri66m) 's mention of local and remote backups in different regions could also be a point of consideration for this page

## JIRA
[DOCSP-49287](https://jira.mongodb.org/browse/DOCSP-49287)
## STAGING
https://deploy-preview-172--docs-atlas-architecture.netlify.app/backups/