### PR TITLE
Add unified TF directory for prod and staging

### DIFF
--- a/source/includes/complete-examples.rst
+++ b/source/includes/complete-examples.rst
@@ -1,6 +1,6 @@
 .. cta-banner::
-   :url: https://github.com/mongodb/docs-atlas-architecture/blob/main/source/includes/examples/tf-example-complete-staging-prod.tf
+   :url: https://github.com/mongodb/docs-atlas-architecture/blob/main/source/includes/examples/tf-staging-prod-complete/
    :icon: Code
 
-   See Terraform examples to enforce our Staging/Prod recommendations across all pillars in one place `in Github <https://github.com/mongodb/docs-atlas-architecture/blob/main/source/includes/examples/tf-example-complete-staging-prod.tf>`__.
+   See Terraform examples to enforce our Staging/Prod recommendations across all pillars in one place `in Github <https://github.com/mongodb/docs-atlas-architecture/blob/main/source/includes/examples/tf-staging-prod-complete/>`__.
 

--- a/source/includes/examples/tf-staging-prod-complete/azure.tf
+++ b/source/includes/examples/tf-staging-prod-complete/azure.tf
@@ -1,0 +1,91 @@
+locals {
+  tags = {
+       CreatedBy = "Terraform"
+       Module    = "tf-example-oidc-azure"
+       Name      = var.atlas_project_name
+  }
+}
+
+resource "azurerm_resource_group" "this" {
+  name     = var.atlas_project_name
+  location = var.atlas_region
+  tags     = local.tags
+}
+
+resource "azurerm_virtual_network" "this" {
+  name                = var.atlas_project_name
+  address_space       = ["10.0.0.0/16"]
+  location            = azurerm_resource_group.this.location
+  resource_group_name = azurerm_resource_group.this.name
+  tags                = local.tags
+}
+
+resource "azurerm_subnet" "internal" {
+  name                 = "internal"
+  resource_group_name  = azurerm_resource_group.this.name
+  virtual_network_name = azurerm_virtual_network.this.name
+  address_prefixes     = ["10.0.2.0/24"]
+}
+
+resource "azurerm_public_ip" "vm-public-ip" {
+  name                = "public-ip-${var.atlas_project_name}"
+  location            = var.atlas_region
+  resource_group_name = azurerm_resource_group.this.name
+  allocation_method   = "Dynamic"
+  domain_name_label   = var.atlas_project_name
+  tags                = local.tags
+}
+
+resource "azurerm_network_interface" "this" {
+  name                = "ip-${var.atlas_project_name}"
+  location            = var.atlas_region
+  resource_group_name = azurerm_resource_group.this.name
+  tags                = local.tags
+
+  ip_configuration {
+       subnet_id                     = azurerm_subnet.internal.id
+       name                          = "public"
+       private_ip_address_allocation = "Dynamic"
+       public_ip_address_id          = azurerm_public_ip.vm-public-ip.id
+  }
+}
+
+resource "azurerm_user_assigned_identity" "this" {
+  location            = var.atlas_region
+  name                = var.atlas_project_name
+  resource_group_name = azurerm_resource_group.this.name
+  tags                = local.tags
+}
+
+resource "azurerm_linux_virtual_machine" "this" {
+  name                  = var.atlas_project_name
+  resource_group_name   = azurerm_resource_group.this.name
+  location              = var.atlas_region
+  size                  = "Standard_F2"
+  admin_username        = var.vm_admin_username
+  network_interface_ids = [azurerm_network_interface.this.id]
+  tags                  = local.tags
+
+  admin_ssh_key {
+       username   = var.vm_admin_username
+       public_key = var.ssh_public_key
+  }
+
+  source_image_reference {
+       publisher = "Canonical"
+       offer     = "0001-com-ubuntu-server-jammy"
+       sku       = "22_04-lts"
+       version   = "latest"
+  }
+
+  os_disk {
+       storage_account_type = "Standard_LRS"
+       caching              = "ReadWrite"
+       disk_size_gb         = 30
+  }
+
+  identity {
+       type = "UserAssigned"
+       identity_ids = [azurerm_user_assigned_identity.this.id]
+  }
+}

--- a/source/includes/examples/tf-staging-prod-complete/main.tf
+++ b/source/includes/examples/tf-staging-prod-complete/main.tf
@@ -1,0 +1,374 @@
+# Create a Group to Assign to Project
+resource "mongodbatlas_team" "project_group" {
+  org_id = var.atlas_org_id
+  name   = var.atlas_group_name
+  usernames = [
+    "user1@example.com",
+    "user2@example.com"
+  ]
+}
+
+# Create a Project
+resource "mongodbatlas_project" "atlas-project" {
+  org_id = var.atlas_org_id
+  name = var.atlas_project_name
+  # Assign the Project with Specific Roles
+    teams {
+      team_id    = mongodbatlas_team.project_group.team_id
+      role_names = ["GROUP_READ_ONLY", "GROUP_CLUSTER_MANAGER"]
+    }
+}
+
+# Create an Atlas Advanced Cluster
+resource "mongodbatlas_advanced_cluster" "atlas-cluster" {
+  project_id = mongodbatlas_project.atlas-project.id
+  name = "ClusterPortalProd"
+  cluster_type = "REPLICASET"
+  mongo_db_major_version = var.mongodb_version
+  replication_specs {
+    region_configs {
+      electable_specs {
+        instance_size = var.cluster_instance_size_name
+        node_count    = 3
+      }
+      priority      = 7
+      provider_name = var.cloud_provider
+      region_name   = var.atlas_region
+    }
+  }
+  tags {
+    key   = "BU"
+    value = "ConsumerProducts"
+  }
+  tags {
+    key   = "TeamName"
+    value = "TeamA"
+  }
+  tags {
+    key   = "AppName"
+    value = "ProductManagementApp"
+  }
+  tags {
+    key   = "Env"
+    value = "Production"
+  }
+  tags {
+    key   = "Version"
+    value = "8.0"
+  }
+  tags {
+    key   = "Email"
+    value = "test@test.com"
+  }
+}
+
+# Outputs to Display
+output "atlas_cluster_connection_string" {
+  value = mongodbatlas_advanced_cluster.atlas-cluster.connection_strings.0.standard_srv
+}
+output "project_name" {
+  value = mongodbatlas_project.atlas-project.name
+}
+
+# Set up an alert notification by email when there is replication lag
+# Greater than 1 hour for more than 5 minutes
+resource "mongodbatlas_alert_configuration" "test_replication_lag_alert" {
+  project_id = mongodbatlas_project.atlas-project.id
+  event_type = "OUTSIDE_METRIC_THRESHOLD"
+  enabled    = true
+  notification {
+    type_name     = "GROUP"
+    interval_min  = 10
+    delay_min     = 0
+    sms_enabled   = false
+    email_enabled = true
+    roles         = ["GROUP_CLUSTER_MANAGER"]
+  }
+  matcher {
+    field_name = "CLUSTER_NAME"
+    operator   = "EQUALS"
+    value      = "myCluster"
+  }
+  metric_threshold_config {
+    metric_name = "OPLOG_SLAVE_LAG_MASTER_TIME"
+    operator    = "GREATER_THAN"
+    threshold   = 1
+    units       = "HOURS"
+  }
+}
+
+# Connection string to use in this configuration
+locals {
+  mongodb_uri = var.connection_strings[0]
+}
+
+# Atlas organization details to use in the configuration
+data "mongodbatlas_federated_settings" "this" {
+  org_id = var.atlas_org_id
+}
+
+# Configure an identity provider for federated authentication
+# For IAM roles and Azure assigned identities, you must create the 
+# role or identity and declare the variable before you use this 
+# Terraform resource
+resource "mongodbatlas_federated_settings_identity_provider" "oidc" {
+  federation_settings_id = data.mongodbatlas_federated_settings.this.id
+  audience               = var.token_audience
+  authorization_type     = "USER"
+  description            = "oidc-for-azure"
+  issuer_uri = "https://sts.windows.net/${azurerm_user_assigned_identity.this.tenant_id}/"
+  idp_type   = "WORKLOAD"
+  name       = "OIDC-for-azure"
+  protocol   = "OIDC"
+  user_claim = "sub"
+}
+
+resource "mongodbatlas_federated_settings_org_config" "this" {
+  federation_settings_id            = data.mongodbatlas_federated_settings.this.id
+  org_id                            = var.atlas_org_id
+  domain_restriction_enabled        = false
+  domain_allow_list                 = []
+  data_access_identity_provider_ids = [mongodbatlas_federated_settings_identity_provider.oidc.idp_id]
+}
+
+# Create an OIDC federated authentication user
+# For IAM roles and Azure assigned identities, you must create the 
+# role or identity and declare the variable before you use this 
+# Terraform resource
+resource "mongodbatlas_database_user" "oidc" {
+  project_id         = mongodbatlas_project.atlas-project.id
+  username           = "${mongodbatlas_federated_settings_identity_provider.oidc.idp_id}/${azurerm_user_assigned_identity.this.principal_id}"
+  oidc_auth_type     = "USER"
+  auth_database_name = "$external" # required when using OIDC USER authentication
+  
+  roles {
+    role_name     = "atlasAdmin"
+    database_name = "admin"
+  }
+}
+
+# Configure a custom role
+resource "mongodbatlas_custom_db_role" "create_role" {
+  project_id = mongodbatlas_project.atlas-project.id
+  role_name  = "my_custom_role"
+  actions {
+    action = "UPDATE"
+    resources {
+      database_name   = "myDb"
+    }
+  }
+  actions {
+    action = "INSERT"
+    resources {
+      database_name   = "myDb"
+    }
+  }
+  actions {
+    action = "REMOVE"
+    resources {
+      database_name   = "myDb"
+    }
+  }
+}
+
+# AWS ONLY - Create a Private Link
+resource "mongodbatlas_privatelink_endpoint" "aws_test" {
+  # Conditionally create this resource if the provider is "AWS"
+  count = var.cloud_provider == "AWS" ? 1 : 0 
+  project_id = mongodbatlas_project.atlas-project.id
+  provider_name = "AWS"
+  region        = "US_EAST_1"
+
+  timeouts {
+    create = "30m"
+    delete = "20m"
+  }
+}
+
+# AZURE ONLY - Create a Private Link
+resource "mongodbatlas_privatelink_endpoint" "azure_test" {
+  # Conditionally create this resource if the provider is "AZURE"
+  count = var.cloud_provider == "AZURE" ? 1 : 0
+  project_id = mongodbatlas_project.atlas-project.id
+  provider_name = "AZURE"
+  region        = "US_EAST_1"
+
+  timeouts {
+    create = "30m"
+    delete = "20m"
+  }
+}
+
+# AWS ONLY - Enable BYOK encryption
+resource "mongodbatlas_cloud_provider_access_setup" "aws_setup_only" {
+  # Conditionally create this resource if the provider is "AWS"
+  count = var.cloud_provider == "AWS" ? 1 : 0
+  project_id = mongodbatlas_project.atlas-project.id
+  provider_name = "AWS"
+}
+
+# AWS ONLY - Enable BYOK encryption
+# For IAM roles and Azure assigned identities, you must create the 
+# role or identity and declare the variable before you use this 
+# Terraform resource
+resource "mongodbatlas_cloud_provider_access_authorization" "aws_auth_role" {
+  # conditionally create this resource if the provider is "AWS"
+  count = var.cloud_provider == "AWS" ? 1 : 0
+  project_id = mongodbatlas_project.atlas-project.id
+  role_id    = mongodbatlas_cloud_provider_access_setup.aws_setup_only[0].role_id
+
+  # aws {
+  #   iam_assumed_role_arn = aws_iam_role.test_role.arn
+  # }
+}
+
+# AWS ONLY - Enable BYOK encryption
+# For KMS keys, you must create the 
+# key and declare the variable before you use this 
+# Terraform resource
+resource "mongodbatlas_encryption_at_rest" "aws_test" {
+  # conditionally create this resource if the provider is "AWS"
+  count = var.cloud_provider == "AWS" ? 1 : 0
+  project_id = mongodbatlas_project.atlas-project.id
+
+  aws_kms_config {
+    enabled                = true
+    customer_master_key_id = "<Your KMS key>"
+    region                 = var.atlas_region
+    role_id                = mongodbatlas_cloud_provider_access_authorization.aws_auth_role[0].role_id
+  }
+}
+
+data "mongodbatlas_encryption_at_rest" "test" {
+  project_id = mongodbatlas_project.atlas-project.id
+}
+
+# AZURE ONLY - Enable BYOK encryption
+resource "mongodbatlas_encryption_at_rest" "azure_test" {
+  # conditionally create this resource if the provider is "AZURE"
+  count = var.cloud_provider == "AZURE" ? 1 : 0
+  project_id = mongodbatlas_project.atlas-project.id
+
+  azure_key_vault_config {
+    enabled           = true
+    azure_environment = "AZURE"
+
+    tenant_id       = var.azure_tenant_id
+    subscription_id = var.azure_subscription_id
+    client_id       = var.azure_client_id
+    secret          = var.azure_client_secret
+
+    resource_group_name = var.azure_resource_group_name
+    key_vault_name      = var.azure_key_vault_name
+    key_identifier      = var.azure_key_identifier
+  }
+}
+
+# GCP ONLY - Enable BYOK encryption
+resource "mongodbatlas_encryption_at_rest" "gcp_test" {
+  # conditionally create this resource if the provider is "GCP"
+  count = var.cloud_provider == "GCP" ? 1 : 0
+  project_id = mongodbatlas_project.atlas-project.id
+
+  google_cloud_kms_config {
+    enabled                 = true
+    service_account_key     = "{\"type\": \"service_account\",\"project_id\": \"my-project-common-0\",\"private_key_id\": \"e120598ea4f88249469fcdd75a9a785c1bb3\",\"private_key\": \"-----BEGIN PRIVATE KEY-----\\nMIIEuwIBA(truncated)SfecnS0mT94D9\\n-----END PRIVATE KEY-----\\n\",\"client_email\": \"my-email-kms-0@my-project-common-0.iam.gserviceaccount.com\",\"client_id\": \"10180967717292066\",\"auth_uri\": \"https://accounts.google.com/o/oauth2/auth\",\"token_uri\": \"https://accounts.google.com/o/oauth2/token\",\"auth_provider_x509_cert_url\": \"https://www.googleapis.com/oauth2/v1/certs\",\"client_x509_cert_url\": \"https://www.googleapis.com/robot/v1/metadata/x509/my-email-kms-0%40my-project-common-0.iam.gserviceaccount.com\"}"
+    key_version_resource_id = "projects/my-project-common-0/locations/us-east4/keyRings/my-key-ring-0/cryptoKeys/my-key-0/cryptoKeyVersions/1"
+  }
+}
+
+# Enable auditing and create an audit filter for your cluster
+resource "mongodbatlas_auditing" "test" {
+  project_id = mongodbatlas_project.atlas-project.id
+  audit_filter                = "{ 'atype': 'authenticate', 'param': {   'user': 'auditAdmin',   'db': 'admin',   'mechanism': 'SCRAM-SHA-1' }}"
+  audit_authorization_success = false
+  enabled                     = true
+}
+
+# Configure backup schedule
+locals {
+  atlas_clusters = {
+    "cluster_1" = { name = "m10-aws-1e", region = "US_EAST_1" },
+    "cluster_2" = { name = "m10-aws-2e", region = "US_EAST_2" },
+  }
+}
+
+resource "mongodbatlas_advanced_cluster" "automated_backup_test_cluster" {
+  for_each     = local.atlas_clusters
+  project_id   = mongodbatlas_project.atlas-project.id
+  name         = each.value.name
+  cluster_type = "REPLICASET"
+
+  replication_specs {
+    region_configs {
+      electable_specs {
+        instance_size = "M10"
+        node_count    = 3
+      }
+      analytics_specs {
+        instance_size = "M10"
+        node_count    = 1
+      }
+
+      provider_name = "AWS"
+      region_name   = each.value.region
+      priority      = 7
+    }
+  }
+
+  backup_enabled = true # enable cloud backup snapshots
+  pit_enabled    = true
+}
+
+resource "mongodbatlas_cloud_backup_schedule" "test" {
+  for_each                 = local.atlas_clusters
+  project_id               = mongodbatlas_project.atlas-project.id
+  cluster_name             = mongodbatlas_advanced_cluster.automated_backup_test_cluster[each.key].name
+  reference_hour_of_day    = 3
+  reference_minute_of_hour = 45
+  restore_window_days      = 4
+
+  copy_settings {
+    cloud_provider = "AWS"
+    frequencies = ["HOURLY",
+      "DAILY",
+      "WEEKLY",
+      "MONTHLY",
+      "YEARLY",
+      "ON_DEMAND"]
+    region_name        = "US_WEST_1"
+    zone_id            = mongodbatlas_advanced_cluster.automated_backup_test_cluster[each.key].replication_specs.*.zone_id[0]
+    should_copy_oplogs = true
+  }
+
+  policy_item_hourly {
+    frequency_interval = 1 #accepted values = 1, 2, 4, 6, 8, 12 -> every n hours
+    retention_unit     = "days"
+    retention_value    = 4
+  }
+  policy_item_daily {
+    frequency_interval = 1 #accepted values = 1 -> every 1 day
+    retention_unit     = "days"
+    retention_value    = 4
+  }
+  policy_item_weekly {
+    frequency_interval = 4 # accepted values = 1 to 7 -> every 1=Monday,2=Tuesday,3=Wednesday,4=Thursday,5=Friday,6=Saturday,7=Sunday day of the week
+    retention_unit     = "weeks"
+    retention_value    = 4
+  }
+  policy_item_monthly {
+    frequency_interval = 5 # accepted values = 1 to 28 -> 1 to 28 every nth day of the month
+    # accepted values = 40 -> every last day of the month
+    retention_unit  = "months"
+    retention_value = 4
+  }
+  policy_item_yearly {
+    frequency_interval = 1 # accepted values = 1 to 12 -> 1st day of nth month
+    retention_unit     = "years"
+    retention_value    = 4
+  }
+
+  depends_on = [
+    mongodbatlas_advanced_cluster.automated_backup_test_cluster
+  ]
+}

--- a/source/includes/examples/tf-staging-prod-complete/provider.tf
+++ b/source/includes/examples/tf-staging-prod-complete/provider.tf
@@ -1,0 +1,9 @@
+# Define the MongoDB Atlas Provider
+terraform {
+  required_providers {
+    mongodbatlas = {
+      source = "mongodb/mongodbatlas"
+    }
+  }
+  required_version = ">= 0.13"
+}

--- a/source/includes/examples/tf-staging-prod-complete/terraform.tfvars
+++ b/source/includes/examples/tf-staging-prod-complete/terraform.tfvars
@@ -1,0 +1,33 @@
+atlas_org_id = "<Organization ID>"
+atlas_project_name = "<Project name>"
+environment = "prod"
+cluster_instance_size_name = "M30"
+cloud_provider = "Azure"
+atlas_region = "<Region>"
+mongodb_version = "8.0"
+atlas_group_name = "Atlas Group"
+
+atlas_project_id = "<Project ID>"
+atlas_cluster_name = "<Cluster Name>"
+datadog_api_key = "<API Key>"
+datadog_region = "US5"
+prometheus_user_name = "<Prometheus username>"
+prometheus_password = "<Prometheus Password>"
+
+connection_strings = ["<Connection string>"]
+token_audience = "https://management.azure.com/"
+
+auto_scaling_disk_gb = true
+auto_scaling_compute = true
+disk_size_gb = 40000
+
+azure_tenant_id = "<Azure Tenant ID>"
+azure_subscription_id = "<Azure Subscription ID>"
+azure_client_id = "<Azure Client ID>"
+azure_client_secret = "<Azure Client Secret>"
+azure_resource_group_name = "<Azure Resource Group Name>"
+azure_key_vault_name = "<Azure Key Vault Name>"
+azure_key_identifier = "<Azure Key Identifier>"
+
+vm_admin_username="<Admin username>"
+ssh_public_key="<SSH public key>"

--- a/source/includes/examples/tf-staging-prod-complete/variables.tf
+++ b/source/includes/examples/tf-staging-prod-complete/variables.tf
@@ -1,0 +1,164 @@
+# Atlas Organization ID
+variable "atlas_org_id" {
+  type        = string
+  description = "Atlas Organization ID"
+}
+
+# Atlas Project Name
+variable "atlas_project_name" {
+  type        = string
+  description = "Atlas Project Name"
+}
+
+# Atlas Project Environment
+variable "environment" {
+  type        = string
+  description = "The environment to be built"
+}
+
+# Cluster Instance Size Name
+variable "cluster_instance_size_name" {
+  type        = string
+  description = "Cluster instance size name"
+}
+
+# Cloud Provider to Host Atlas Cluster
+variable "cloud_provider" {
+  type        = string
+  description = "AWS or GCP or Azure"
+}
+
+# Atlas Region
+variable "atlas_region" {
+  type        = string
+  description = "Atlas region where resources will be created"
+}
+
+# MongoDB Version
+variable "mongodb_version" {
+  type        = string
+  description = "MongoDB Version"
+}
+
+# Atlas Group Name
+variable "atlas_group_name" {
+  type        = string
+  description = "Atlas Group Name"
+}
+
+# Storage Auto-scaling Enablement Flag
+variable "auto_scaling_disk_gb" {
+  type        = bool
+  description = "Flag that specifies whether disk auto-scaling is enabled"
+}
+
+# Compute Auto-scaling Enablement Flag
+variable "auto_scaling_compute" {
+  type        = bool
+  description = "Flag that specifies whether cluster tier auto-scaling is enabled"
+}
+
+# Disk Size in GB
+variable "disk_size_gb" {
+  type        = number
+  description = "Disk Size in GB"
+}
+
+# Atlas Project ID
+variable "atlas_project_id" {
+  type        = string
+  description = "MongoDB Atlas project id"
+}
+
+# Atlas Cluster Name
+variable "atlas_cluster_name" {
+  type        = string
+  description = "MongoDB Atlas Cluster Name"
+  default     = "datadog-test-cluster"
+}
+
+# Datadog API Key
+variable "datadog_api_key" {
+  type        = string
+  description = "Datadog api key"
+}
+
+# Datadog Region
+variable "datadog_region" {
+  type        = string
+  description = "Datadog region"
+  default     = "US5"
+}
+
+# Prometheus User Name
+variable "prometheus_user_name" {
+  type        = string
+  description = "The Prometheus User Name"
+  default     = "puser"
+}
+
+# Prometheus Password
+variable "prometheus_password" {
+  type        = string
+  description = "The Prometheus Password"
+  default     = "ppassword"
+}
+
+# Azure Variables
+
+variable "token_audience" {
+  type        = string
+  default     = "https://management.azure.com/"
+  description = "Used as resource when getting the access token. See more in the [Azure documentation](https://learn.microsoft.com/en-us/entra/identity/managed-identities-azure-resources/how-to-use-vm-token#get-a-token-using-http)"
+}
+
+variable "azure_tenant_id" {
+  type        = string
+  description = "Azure Tenant ID"
+}
+
+variable "azure_subscription_id" {
+  type        = string
+  description = "Azure Subscription ID"
+}
+
+variable "azure_client_id" {
+  type        = string
+  description = "Azure Client ID"
+}
+
+variable "azure_client_secret" {
+  type        = string
+  description = "Azure Client Secret"
+}
+
+variable "azure_resource_group_name" {
+  type        = string
+  description = "Azure Resource Group Name"
+}
+
+variable "azure_key_vault_name" {
+  type        = string
+  description = "Azure Key Vault Name"
+}
+
+variable "azure_key_identifier" {
+  type        = string
+  description = "Azure Key Identifier"
+}
+
+# MongoDB Atlas variables
+variable "connection_strings" {
+  type        = list(string)
+  description = "MongoDB Atlas Cluster Standard Connection Strings"
+}
+
+variable "vm_admin_username" {
+  type        = string
+  description = "VM Admin Username"
+}
+
+variable "ssh_public_key" {
+  type        = string
+  description = "SSH Public Key"
+}


### PR DESCRIPTION
Updated the existing `tf-example-complete-staging-prod.tf` to include the most up to date code featured in the Arch center. Moved the file into its own directory and added the necessary variable/provider files from the existing examples.

This PR does not include any net-new code. It combines all existing code examples from the various pages into one directory. Most of the code changes were adding missing variable declarations and updating variable names to be consistent between all examples, and fixing any code errors that rose when running `terraform plan`