### PR TITLE
fix-customer-count-sols-library-landing-page

### DIFF
--- a/source/solutions-library.txt
+++ b/source/solutions-library.txt
@@ -4,7 +4,7 @@
 Solutions Library
 =================
 
-Drawing from experience with over 54,500 customers, the Solutions
+Drawing from experience with over 57,100 customers, the Solutions
 Library is curated with tailored solutions to help developers 
 kick-start their projects. 
 


### PR DESCRIPTION
Change "54,500 customers" to "57,100 customers" on Sols Library landing page ([slack thread](https://mongodb.slack.com/archives/C08MCJX1VFV/p1749228187231489))

## STAGING

https://deploy-preview-253--docs-atlas-architecture.netlify.app/solutions-library/