### PR TITLE
hide pre-release version of site

### DIFF
--- a/config/redirects
+++ b/config/redirects
@@ -14,3 +14,31 @@ raw: ${bucket_prefix}/index.html -> ${base}/current/
 # All Arch Center versions
 
 [*]: ${bucket_prefix}/${version}/changelog -> ${base}/${version}/release-notes/
+
+
+# hide unversioned prerelease version of site
+
+raw: ${bucket_prefix}/ -> ${base}/current/
+raw: ${bucket_prefix}/getting-started/ -> ${base}/current/getting-started/
+raw: ${bucket_prefix}/landing-zone/ -> ${base}/current/landing-zone/
+raw: ${bucket_prefix}/hierarchy/ -> ${base}/current/hierarchy/
+raw: ${bucket_prefix}/operational-efficiency/ -> ${base}/current/operational-efficiency/
+raw: ${bucket_prefix}/automation/ -> ${base}/current/automation/
+raw: ${bucket_prefix}/monitoring-alerts/ -> ${base}/current/monitoring-alerts/
+raw: ${bucket_prefix}/security/ -> ${base}/current/security/
+raw: ${bucket_prefix}/network-security/ -> ${base}/current/network-security/
+raw: ${bucket_prefix}/auth/ -> ${base}/current/auth/
+raw: ${bucket_prefix}/data-encryption/ -> ${base}/current/data-encryption/
+raw: ${bucket_prefix}/compliance/ -> ${base}/current/compliance/
+raw: ${bucket_prefix}/auditing-logging/ -> ${base}/current/auditing-logging/
+raw: ${bucket_prefix}/reliability/ -> ${base}/current/reliability/
+raw: ${bucket_prefix}/high-availability/ -> ${base}/current/high-availability/
+raw: ${bucket_prefix}/resiliency/ -> ${base}/current/resiliency/
+raw: ${bucket_prefix}/backups/ -> ${base}/current/backups/
+raw: ${bucket_prefix}/disaster-recovery/ -> ${base}/current/disaster-recovery/
+raw: ${bucket_prefix}/performance/ -> ${base}/current/performance/
+raw: ${bucket_prefix}/scalability/ -> ${base}/current/scalability/
+raw: ${bucket_prefix}/cost-optimization/ -> ${base}/current/cost-optimization/
+raw: ${bucket_prefix}/cost-saving-config/ -> ${base}/current/cost-saving-config/
+raw: ${bucket_prefix}/billing-data/ -> ${base}/current/billing-data/
+raw: ${bucket_prefix}/release-notes/ -> ${base}/current/release-notes/


### PR DESCRIPTION
an earlier version of the architecture center was published to docs/atlas/architecture/. We later decided to version this content, keeping the most recent at docs/atlas/architecture/current/.

Adding redirects to prevent readers from visiting the older versions of these pages.