### PR TITLE
removed references to OpenAI

### DIFF
--- a/source/solutions-library/manufacturing-asset-predictive-maintenance.txt
+++ b/source/solutions-library/manufacturing-asset-predictive-maintenance.txt
@@ -33,16 +33,13 @@ predict failures, generate repair plans, and reduce downtime.
 <https://www.mongodb.com/solutions/industries/manufacturing>`__,
 Aerospace & Defense, Energy & Environmental
 
-**Products:** `MongoDB Atlas <http://mongodb.com/atlas>`__, `Atlas
-Charts <https://www.mongodb.com/products/platform/atlas-charts>`__,
-`Atlas Stream Processing
-<https://www.mongodb.com/products/platform/atlas-stream-processing>`__,
-`Atlas Vector Search
-<https://www.mongodb.com/products/platform/atlas-vector-search>`__
+**Products:** `MongoDB Atlas <http://mongodb.com/atlas>`__, 
+`Atlas Charts <https://www.mongodb.com/products/platform/atlas-charts>`__,
+`Atlas Stream Processing <https://www.mongodb.com/products/platform/atlas-stream-processing>`__,
+`Atlas Vector Search <https://www.mongodb.com/products/platform/atlas-vector-search>`__
 
-**Partners:** `Cohere
-<https://cloud.mongodb.com/ecosystem/cohere>`__, `LangChain
-<https://cloud.mongodb.com/ecosystem/langchain>`__ 
+**Partners:** `Cohere <https://cloud.mongodb.com/ecosystem/cohere>`__, 
+`LangChain <https://cloud.mongodb.com/ecosystem/langchain>`__ 
 
 Solution Overview
 -----------------
@@ -203,9 +200,9 @@ This architecture enhances operator instructions through a RAG approach:
    
    Figure 5. RAG workflow enhances technician repair instructions
 
-Each architecture integrates with MongoDB Atlas core capabilities while
-leveraging external services (Amazon Bedrock, OpenAI, Cohere) for AI/ML
-functionality, creating a comprehensive predictive maintenance solution.
+Each architecture integrates core capabilities of MongoDB Atlas and uses
+external services, such as Amazon Bedrock or Cohere, for AI
+functionality.
 
 Building the Solution
 ---------------------
@@ -250,8 +247,9 @@ Building the Solution
           cohere.embed-english-v3 for embeddings, cohere.command-r-10
           for completions).
 
-        - Option 2 - OpenAI: Set up API access and select appropriate
-          model.
+        - Option 2 - Direct API access: Set up integration with a
+          third-party provider of your choice for embeddings and
+          completions.
 
       - Set up Google Cloud Translation API for multilingual support.
 

--- a/source/solutions-library/manufacturing-asset-predictive-maintenance.txt
+++ b/source/solutions-library/manufacturing-asset-predictive-maintenance.txt
@@ -242,12 +242,12 @@ Building the Solution
 
       - Select one LLM provider for your implementation:
 
-        - Option 1 - Amazon Bedrock: Configure access to Cohere models
+        - **Amazon Bedrock:** Configure access to Cohere models
           for embeddings and completions (Examples of available models:
           cohere.embed-english-v3 for embeddings, cohere.command-r-10
           for completions).
 
-        - Option 2 - Direct API access: Set up integration with a
+        - **Direct API access:** Set up integration with a
           third-party provider of your choice for embeddings and
           completions.
 


### PR DESCRIPTION
This is a test request for workflow for update solutions library.

We removed references to OpenAI in the Predictive Maintenance Excellence solution. 

Staging
--------
[Predictive Maintenance Excellence with MongoDB Atlas](https://deploy-preview-257--docs-atlas-architecture.netlify.app/solutions-library/manufacturing-asset-predictive-maintenance/)